### PR TITLE
merge nodes when databases out of sync.

### DIFF
--- a/pipeline/add_contig_taxonomy.py
+++ b/pipeline/add_contig_taxonomy.py
@@ -346,7 +346,7 @@ output_file_path = sys.argv[4]
 # Process NCBI taxdump files
 name_fpath = os.path.join(taxdump_dir_path, 'names.dmp')
 nodes_fpath = os.path.join(taxdump_dir_path, 'nodes.dmp')
-nodes_fpath = os.path.join(taxdump_dir_path, 'merged.dmp')
+merged_fpath = os.path.join(taxdump_dir_path, 'merged.dmp')
 
 pp = pprint.PrettyPrinter(indent=4)
 

--- a/pipeline/add_contig_taxonomy.py
+++ b/pipeline/add_contig_taxonomy.py
@@ -346,6 +346,7 @@ output_file_path = sys.argv[4]
 # Process NCBI taxdump files
 name_fpath = os.path.join(taxdump_dir_path, 'names.dmp')
 nodes_fpath = os.path.join(taxdump_dir_path, 'nodes.dmp')
+nodes_fpath = os.path.join(taxdump_dir_path, 'merged.dmp')
 
 pp = pprint.PrettyPrinter(indent=4)
 

--- a/pipeline/make_taxonomy_table.py
+++ b/pipeline/make_taxonomy_table.py
@@ -164,7 +164,7 @@ def update_dbs(database_path, db='all'):
 			download_file(database_path, taxdump_url, taxdump_md5_url)
 
 		if os.path.isfile(database_path + '/taxdump.tar.gz'):
-			run_command('tar -xzf {}/taxdump.tar.gz -C {} names.dmp nodes.dmp'.format(database_path, database_path))
+			run_command('tar -xzf {}/taxdump.tar.gz -C {} names.dmp nodes.dmp merged.dmp'.format(database_path, database_path))
 			os.remove('{}/taxdump.tar.gz'.format(database_path))
 			print("nodes.dmp and names.dmp updated")
 
@@ -183,7 +183,7 @@ def check_dbs(db_path):
 		db_dict = {
 			'nr': ['nr.dmnd'],
 			'acc2taxid': ['prot.accession2taxid'],
-			'taxdump': ['names.dmp','nodes.dmp']
+			'taxdump': ['names.dmp','nodes.dmp', 'merged.dmp']
 			}
 	db_files = os.listdir(db_path)
 	for db in db_dict:
@@ -303,7 +303,7 @@ parser.add_argument('-bgc', '--bgcs_dir', metavar='<dir>',
 parser.add_argument('-s', '--single_genome', help='Specifies single genome mode',
 	action='store_true')
 parser.add_argument('-u', '--update', required=False, action='store_true',
-	help='Checks/Adds/Updates: nodes.dmp, names.dmp, accession2taxid, nr.dmnd files within specified directory.')
+	help='Checks/Adds/Updates: nodes.dmp, names.dmp, merged.dmp, accession2taxid, nr.dmnd files within specified directory.')
 
 args = vars(parser.parse_args())
 


### PR DESCRIPTION
This issue has since been resolved in the refactored version. This is a hotfix to master.

The error occurs when the `nr.dmnd` database search and `prot.accession2taxid.gz` recovers taxids different from the tree structure within nodes.dmp. This is easily resolved as NCBI has similarly provided a `merged.dmp` file with the old to new taxid translations.

```python
# The below method will translate any old taxids otherwise the assigned taxid will be used.
taxid = merged.get(taxid,taxid)
```