### PR TITLE
🐛found in coverage

### DIFF
--- a/autometa/common/coverage.py
+++ b/autometa/common/coverage.py
@@ -57,7 +57,7 @@ def from_spades_names(records):
         index=contig, name='coverage', dtype=float
 
     """
-    logger.info(f'Retrieving coverages from contig ID in {args.assembly}')
+    logger.info(f'Retrieving coverages from contig ID in {len(records):,} records')
     coverages = pd.Series(
         {record.id:record.id.split('_cov_')[-1] for record in records},
         name='coverage',


### PR DESCRIPTION
Bug found within logger message within function where `args` was being passed instead of records. (Thanks @samche42)