### PR TITLE
Add functionality to bin without taxonomy. Update docstrings

### DIFF
--- a/autometa/config/__init__.py
+++ b/autometa/config/__init__.py
@@ -39,6 +39,25 @@ DEFAULT_FPATH = os.path.join(os.path.dirname(__file__), 'default.config')
 AUTOMETA_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 def get_config(fpath):
+    """Load the config provided at `fpath`.
+
+    Parameters
+    ----------
+    fpath : str
+        </path/to/file.config>
+
+    Returns
+    -------
+    config.ConfigParser
+        interpolated config object parsed from `fpath`.
+
+    Raises
+    -------
+    FileNotFoundError
+        Provided `fpath` does not exist.
+
+    """
+    # COMBAK: Checkpoint config
     if not os.path.exists(fpath) or os.stat(fpath).st_size == 0:
         raise FileNotFoundError(fpath)
     # https://stackoverflow.com/a/53274707/13118765
@@ -51,13 +70,46 @@ def get_config(fpath):
 DEFAULT_CONFIG = get_config(fpath=DEFAULT_FPATH)
 
 def put_config(config, out):
+    """Writes `config` to `out` and updates checkpoints checksum.
+
+    Parameters
+    ----------
+    config : config.ConfigParser
+        configuration containing user provided parameters and files information.
+    out : str
+        </path/to/output/file.config>
+
+    Returns
+    -------
+    NoneType
+
+    """
     with open(out, 'w') as fh:
         config.write(fh)
+    # COMBAK: Checkpoint config
 
 def update_config(fpath, section, option, value):
-    c = get_config(fpath)
-    c.set(section,option,value)
-    put_config(c, fpath)
+    """Update `fpath` in `section` for `option` with `value`.
+
+    Parameters
+    ----------
+    fpath : str
+        </path/to/file.config>
+    section : str
+        `section` header to update within `fpath`.
+    option : str
+        `option` to update within `section`.
+    value : str
+        `value` to update `option`.
+
+    Returns
+    -------
+    NoneType
+
+    """
+    cfg = get_config(fpath)
+    cfg.set(section,option,value)
+    put_config(cfg, fpath)
     logger.debug(f'updated {fpath} [{section}] option: {option} : {value}')
 
 def parse_config(fpath=None):
@@ -92,6 +144,7 @@ def parse_config(fpath=None):
          'do_pca':bool,
          'pca_dims':int,
          'embedding_method':str,
+         'do_taxonomy':bool,
          'taxon_method':str,
          'reversed':bool,
          'completeness':float,
@@ -133,6 +186,16 @@ def parse_config(fpath=None):
     return namespace
 
 def init_default():
+    """Set the `home_dir` in autometa's default configuration (default.config)
+    based on autometa's current location. If the `home_dir` variable is already
+    set, then this will be used as the `home_dir` location.
+
+    Returns
+    -------
+    str
+        </path/to/package/autometa>
+
+    """
     cfg = get_config(DEFAULT_FPATH)
     home_dir = cfg.get('common','home_dir')
     if not os.path.isdir(home_dir):

--- a/autometa/config/metagenome.config
+++ b/autometa/config/metagenome.config
@@ -61,6 +61,7 @@ kmer_normalize = True
 do_pca = True
 pca_dims = 50
 embedding_method = UMAP
+do_taxonomy = True
 taxon_method = majority_vote
 reversed = True
 binning_method = recursive_dbscan

--- a/autometa/config/user.py
+++ b/autometa/config/user.py
@@ -36,6 +36,7 @@ from autometa.config import environ
 from autometa.common import utilities
 
 from autometa.common.metagenome import Metagenome
+from autometa.common.mag import MAG
 from autometa.config.databases import Databases
 from autometa.config.project import Project
 from autometa.common.utilities import timeit
@@ -76,9 +77,11 @@ class AutometaUser:
         return self.user_config
 
     def set_home(self):
+        """Set `home_dir` in default.config to current Autometa location."""
         return config.init_default()
 
     def save(self):
+        """Saves the current user config to `self.user_config` file path."""
         config.put_config(self.config, self.user_config)
 
     def configure(self, dryrun=True):
@@ -113,7 +116,7 @@ class AutometaUser:
         self.save()
 
     def new_project(self, fpath):
-        """Configure new project at `outdir`.
+        """Configure new project at `fpath`.
 
         Parameters
         ----------
@@ -122,13 +125,8 @@ class AutometaUser:
 
         Returns
         -------
-        autometa.config.project.Project object
-
-        Raises
-        -------
-        ExceptionName
-            Why the exception is raised.
-
+        autometa.config.project.Project
+            Project object containing methods used to manipulate autometa project
         """
         dpath = os.path.dirname(fpath)
         if not os.path.exists(dpath):
@@ -210,7 +208,7 @@ class AutometaUser:
 
     @utilities.timeit
     def run_binning(self, mgargs):
-        """Run autometa.
+        """Run the autometa metagenome binning pipeline using the provided metagenome args.
 
         Parameters
         ----------
@@ -237,12 +235,15 @@ class AutometaUser:
             rev_reads=mgargs.files.rev_reads,
             se_reads=mgargs.files.se_reads,
             taxon_method=mgargs.parameters.taxon_method)
+
         try:
         # Original (raw) file should not be manipulated so return new object
             mg = mg.length_filter(
                 out=mgargs.files.length_filtered,
                 cutoff=mgargs.parameters.length_cutoff)
+                # COMBAK: Checkpoint length filtered
         except FileExistsError as err:
+            # COMBAK: Checkpoint length filtered
             logger.debug(f'{mgargs.files.length_filtered} already exists. Continuing..')
             mg = Metagenome(
                 assembly=mgargs.files.length_filtered,
@@ -262,6 +263,7 @@ class AutometaUser:
             multiprocess=mgargs.parameters.kmer_multiprocess,
             nproc=mgargs.parameters.cpus,
             force=mgargs.parameters.force)
+        # COMBAK: Checkpoint kmers
 
         coverages = mg.get_coverages(
             out=mgargs.files.coverages,
@@ -270,19 +272,30 @@ class AutometaUser:
             bam=mgargs.files.bam,
             lengths=mgargs.files.lengths,
             bed=mgargs.files.bed)
-        # Filter by Kingdom
-        kingdoms = mg.get_kingdoms(
-            ncbi=mgargs.databases.ncbi,
-            usepickle=mgargs.parameters.usepickle,
-            blast=mgargs.files.blastp,
-            hits=mgargs.files.blastp_hits,
-            force=mgargs.parameters.force,
-            cpus=mgargs.parameters.cpus)
+        # COMBAK: Checkpoint coverages
 
-        if not mgargs.parameters.kingdom in kingdoms:
-            raise KeyError(f'{mgargs.parameters.kingdom} not recovered in dataset. Recovered: {", ".join(kingdoms.keys())}')
+        if mgargs.parameters.do_taxonomy:
+            # Filter by Kingdom
+            kingdoms = mg.get_kingdoms(
+                ncbi=mgargs.databases.ncbi,
+                usepickle=mgargs.parameters.usepickle,
+                blast=mgargs.files.blastp,
+                hits=mgargs.files.blastp_hits,
+                force=mgargs.parameters.force,
+                cpus=mgargs.parameters.cpus)
 
-        mag = kingdoms.get(mgargs.parameters.kingdom)
+            if not mgargs.parameters.kingdom in kingdoms:
+                recovered_kingdoms = ", ".join(kingdoms.keys())
+                raise KeyError(f'{mgargs.parameters.kingdom} not recovered in dataset. Recovered: {recovered_kingdoms}')
+
+            mag = kingdoms.get(mgargs.parameters.kingdom)
+        else:
+            mag = MAG(
+                assembly=mg.assembly,
+                contigs=mg.seqrecords,
+                outdir=mg.outdir)
+
+        # Perform binning
         bins_df = mag.get_binning(
             method=mgargs.parameters.binning_method,
             kmers=mgargs.files.kmer_counts,
@@ -309,9 +322,10 @@ def main():
     parser = argparse.ArgumentParser(description="""
     Configures the Autometa user environment/databases.
     Running without args will download and format Autometa database dependencies.
-    """)
+    """,
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--config',
-        help=f'Path to an Autometa default.config file (default is {config.DEFAULT_FPATH}).',
+        help=f'Path to an Autometa default.config file.',
         default=config.DEFAULT_FPATH)
     parser.add_argument('--dryrun',
         help='Log configuration without performing updates.',
@@ -321,10 +335,10 @@ def main():
         help='Stream debugging information to terminal.',
         action='store_true')
     parser.add_argument('--cpus',
-        help=f'Num. cpus to use when updating/constructing databases (default is {mp.cpu_count()}).',
+        help=f'Num. cpus to use when updating/constructing databases.',
         default=mp.cpu_count(), type=int)
     args = parser.parse_args()
-    # config.init_default()
+
     level = logger.DEBUG if args.debug else logger.INFO
     logger.basicConfig(
         format='[%(asctime)s %(levelname)s] %(name)s: %(message)s',


### PR DESCRIPTION
- :art: Change f-string defaults in argparse parser to use `argparse.ArgumentDefaultsHelpFormatter`
- :art::memo: Add parameter do_taxonomy to metagenome.config
- :art: MAG class now imported in user.py for binning without taxonomy.
- :art::memo: resolves issue-#57
- :art::memo: resolves issue-#58

Note: Add COMBAK comments where checksum functionality should be added. This should be implemented in utilities.py and imported from there.