### PR TITLE
hmmer

### DIFF
--- a/autometa/common/external/hmmer.py
+++ b/autometa/common/external/hmmer.py
@@ -136,7 +136,7 @@ def hmmscan(orfs, hmmdb, outfpath, cpus=0, force=False, parallel=True, log=None)
         logger.error(f'Args:{cmd} ReturnCode:{proc.returncode}')
         raise err
     if not os.path.exists(outfpath):
-        raise OSError(f'{outfpath} not written.')
+        raise FileNotFoundError(f'{outfpath} not written.')
     return outfpath
 
 
@@ -256,20 +256,23 @@ def main():
                         action='store_true')
     parser.add_argument('--cpus', help='num cpus to use', default=0, type=int)
     parser.add_argument(
-        '--parallel', help="Enable GNU parallel", action='store_true')
+        '--parallel', help="enable GNU parallel", action='store_true')
     parser.add_argument('--verbose', help="add verbosity", action='store_true')
     args = parser.parse_args()
 
     if args.verbose:
         logger.setLevel(logger.DEBUG)
-    result = hmmscan(
-        orfs=args.orfs,
-        hmmdb=args.hmmdb,
-        outfpath=args.hmmscan,
-        cpus=args.cpus,
-        force=args.force,
-        parallel=args.parallel,
-        log=args.log)
+    if os.path.exists(args.hmmscan) and os.stat(args.hmmscan).st_size > 0 and not args.force:
+        result = args.hmmscan
+    else:
+        result = hmmscan(
+            orfs=args.orfs,
+            hmmdb=args.hmmdb,
+            outfpath=args.hmmscan,
+            cpus=args.cpus,
+            force=args.force,
+            parallel=args.parallel,
+            log=args.log)
 
     result = filter_markers(
         infpath=result,

--- a/autometa/common/external/hmmer.py
+++ b/autometa/common/external/hmmer.py
@@ -76,7 +76,7 @@ def hmmscan(orfs, hmmdb, outfpath, cpus=0, force=False, parallel=True, log=None)
         hmmscan failed
     """
     # OPTIMIZE: we want to extend parallel to grid computing (workqueue?) via --sshlogin?
-    if os.path.exists(outfpath) and os.stat(outfpath).st_size > 0 and not force:
+    if os.path.exists(outfpath) and os.path.getsize(outfpath) > 0 and not force:
         raise FileExistsError(f'{outfpath}. Use force to overwrite!')
     if parallel:
         outdir = os.path.dirname(os.path.realpath(outfpath))
@@ -206,7 +206,7 @@ def filter_markers(infpath, outfpath, cutoffs, orfs=None, force=False):
     for fp in [infpath, cutoffs]:
         if not os.path.exists(fp):
             raise FileNotFoundError(f'{fp} not found')
-    if os.path.exists(outfpath) and os.stat(outfpath).st_size > 0 and not force:
+    if os.path.exists(outfpath) and os.path.getsize(outfpath) > 0 and not force:
         raise FileExistsError(f'{outfpath} already exists')
     hmmtab_header = ['sname', 'sacc', 'orf', 'score']
     col_indices = [0, 1, 2, 5]

--- a/autometa/common/external/hmmer.py
+++ b/autometa/common/external/hmmer.py
@@ -28,6 +28,7 @@ import logging
 import os
 import subprocess
 import shutil
+import tempfile
 
 import pandas as pd
 
@@ -79,11 +80,9 @@ def hmmscan(orfs, hmmdb, outfpath, cpus=0, force=False, parallel=True, log=None)
     if parallel:
         outdir = os.path.dirname(os.path.realpath(outfpath))
         outprefix = os.path.splitext(os.path.basename(outfpath))[0]
-        tmpdir = os.path.join(outdir, 'tmp')
-        if not os.path.exists(tmpdir):
-            os.makedirs(tmpdir)
-        tmpfname = '.'.join([outprefix, '{#}', 'txt'])
-        tmpfpath = os.path.join(tmpdir, tmpfname)
+        tmp_dirpath = tempfile.mkdtemp(dir=outdir)
+        __, tmp_fpath = tempfile.mkstemp(
+            suffix=".{#}.txt", prefix=outprefix, dir=tmp_dirpath)
         jobs = f'-j{cpus}'
         cmd = [
             'parallel',
@@ -97,7 +96,7 @@ def hmmscan(orfs, hmmdb, outfpath, cpus=0, force=False, parallel=True, log=None)
             'hmmscan',
             '-o', os.devnull,
             '--tblout',
-            tmpfpath,
+            tmp_fpath,
             hmmdb,
             '-',
             '<', orfs,
@@ -112,16 +111,13 @@ def hmmscan(orfs, hmmdb, outfpath, cpus=0, force=False, parallel=True, log=None)
     logger.debug(f'cmd: {" ".join(cmd)}')
     if parallel:
         returncode = subprocess.call(' '.join(cmd), shell=True)
-        tmpfpaths = glob(os.path.join(tmpdir, '*.txt'))
-        lines = ''
-        for fp in tmpfpaths:
-            with open(fp) as fh:
-                for line in fh:
-                    lines += line
-        out = open(outfpath, 'w')
-        out.write(lines)
-        out.close()
-        shutil.rmtree(tmpdir)
+        tmp_fpaths = glob(os.path.join(tmp_dirpath, '*.txt'))
+        with open(outfpath, 'w') as out:
+            for fp in tmp_fpaths:
+                with open(fp) as fh:
+                    for line in fh:
+                        out.write(line)
+        shutil.rmtree(tmp_dirpath)
     else:
         with open(os.devnull, 'w') as STDOUT, open(os.devnull, 'w') as STDERR:
             proc = subprocess.run(cmd, stdout=STDOUT, stderr=STDERR)
@@ -234,10 +230,30 @@ def filter_markers(infpath, outfpath, cutoffs, orfs=None, force=False):
     return outfpath
 
 
-def main(args):
+def main():
+    import argparse
+    import logging as logger
+    logger.basicConfig(
+        format='%(asctime)s : %(name)s : %(levelname)s : %(message)s',
+        datefmt='%m/%d/%Y %I:%M:%S %p')
+    parser = argparse.ArgumentParser(
+        description='Retrieves markers with provided input assembly')
+    parser.add_argument('orfs', help='</path/to/assembly.orfs.faa>')
+    parser.add_argument('hmmdb', help='</path/to/hmmpressed/hmmdb>')
+    parser.add_argument('cutoffs', help='</path/to/hmm/cutoffs.tsv>')
+    parser.add_argument('hmmscan', help='</path/to/hmmscan.out>')
+    parser.add_argument('markers', help='</path/to/markers.tsv>')
+    parser.add_argument('--log', help='</path/to/parallel.log>')
+    parser.add_argument('--force', help="force overwrite of out filepath",
+                        action='store_true')
+    parser.add_argument('--cpus', help='num cpus to use', default=0, type=int)
+    parser.add_argument(
+        '--parallel', help="Enable GNU parallel", action='store_true')
+    parser.add_argument('--verbose', help="add verbosity", action='store_true')
+    args = parser.parse_args()
+
     if args.verbose:
         logger.setLevel(logger.DEBUG)
-
     try:
         result = hmmscan(
             orfs=args.orfs,
@@ -260,24 +276,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    import argparse
-    import logging as logger
-    logger.basicConfig(
-        format='%(asctime)s : %(name)s : %(levelname)s : %(message)s',
-        datefmt='%m/%d/%Y %I:%M:%S %p')
-    parser = argparse.ArgumentParser(
-        description='Retrieves markers with provided input assembly')
-    parser.add_argument('orfs', help='</path/to/assembly.orfs.faa>')
-    parser.add_argument('hmmdb', help='</path/to/hmmpressed/hmmdb>')
-    parser.add_argument('cutoffs', help='</path/to/hmm/cutoffs.tsv>')
-    parser.add_argument('hmmscan', help='</path/to/hmmscan.out>')
-    parser.add_argument('markers', help='</path/to/markers.tsv>')
-    parser.add_argument('--log', help='</path/to/parallel.log>')
-    parser.add_argument('--force', help="force overwrite of out filepath",
-                        action='store_true')
-    parser.add_argument('--cpus', help='num cpus to use', default=0, type=int)
-    parser.add_argument(
-        '--parallel', help="Enable GNU parallel", action='store_true')
-    parser.add_argument('--verbose', help="add verbosity", action='store_true')
-    args = parser.parse_args()
-    main(args)
+    main()

--- a/autometa/common/external/hmmer.py
+++ b/autometa/common/external/hmmer.py
@@ -262,7 +262,7 @@ def main():
 
     if args.verbose:
         logger.setLevel(logger.DEBUG)
-    if os.path.exists(args.hmmscan) and os.stat(args.hmmscan).st_size > 0 and not args.force:
+    if os.path.exists(args.hmmscan) and os.path.getsize(args.hmmscan) > 0 and not args.force:
         result = args.hmmscan
     else:
         result = hmmscan(

--- a/autometa/config/environ.py
+++ b/autometa/config/environ.py
@@ -56,8 +56,6 @@ def which(program):
 
     See: https://stackoverflow.com/a/377028
 
-    Returns:
-        The path if it was valid or None if not
 
     Parameters
     ----------
@@ -67,7 +65,8 @@ def which(program):
     Returns
     -------
     str
-        </path/to/executable/> or ''
+        the path if it was valid or an empty string if not
+        eg. </path/to/executable/> or ''
 
     Raises
     -------
@@ -77,7 +76,8 @@ def which(program):
     """
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-    fpath, fname = os.path.split(program)
+    # check to see if program path is given or just the name
+    fpath, __ = os.path.split(program)
     if fpath:
         if is_exe(program):
             return program
@@ -249,13 +249,16 @@ def bedtools():
 
 
 def get_versions(program=None):
-    """Retrieve versions from all required executable dependencies.
+    """
+    Retrieve versions from all required executable dependencies.
     If `program` is provided will only return version for `program`.
+
+    See: https://stackoverflow.com/a/834451/12671809
 
     Parameters
     ----------
-    program : str
-        the program to retrieve the version.
+    program : str, optional
+        the program to retrieve the version, by default None
 
     Returns
     -------
@@ -269,36 +272,26 @@ def get_versions(program=None):
         `program` is not a string
     KeyError
         `program` is not an executable dependency.
-
     """
-    dispatcher = {
-        'prodigal': prodigal,
-        'diamond': diamond,
-        'hmmsearch': hmmsearch,
-        'hmmpress': hmmpress,
-        'hmmscan': hmmscan,
-        'prodigal': prodigal,
-        'bowtie2': bowtie2,
-        'samtools': samtools,
-        'bedtools': bedtools,
-    }
     if program:
-        exe_name = os.path.basename(program)
         if type(program) is not str:
-            raise ValueError(f'program is not string. given:{type(program)}')
-        if exe_name not in dispatcher:
+            raise TypeError(f'program is not string. given:{type(program)}')
+        exe_name = os.path.basename(program)
+        if exe_name not in globals():
             raise KeyError(f'{exe_name} not in executables')
-        return dispatcher[exe_name]()
+        return (globals()[exe_name]())
     versions = {}
     executables = find_executables()
     for exe, found in executables.items():
         if found:
-            version = dispatcher[exe]()
+            # globals()[exe]() accesses the location of the function for that program
+            # eg. location of bedtools(), prodigal(), etc..
+            version = globals()[exe]()
         else:
             logger.warning(f'VersionUnavailable {exe}')
             version = 'ExecutableNotFound'
         versions.update({exe: version})
-    return versions
+    return (versions)
 
 
 def configure(config=DEFAULT_CONFIG):
@@ -365,7 +358,8 @@ def main():
     parser.add_argument('--out',
                         help='</path/to/output/executables.config>')
     args = parser.parse_args()
-    config, satisfied = configure(infpath=args.infpath)
+    user_config = get_config(args.infpath)
+    config, satisfied = configure(config=user_config)
     if not args.out:
         import sys
         sys.exit(0)


### PR DESCRIPTION
- :art::racehorse: Use tempfile module
- :art: write lines as they are read
- Resolves #43
- :art: code currently in the `if __name__ == __main__:` block moved to main
- :racehorse: Output filehandle writes lines directly as they are being read from temporary file
- :art::racehorse: Replaced manual creation of temporary files with tempfile module
- Did not remove `FileExistsError` from the `except` block of `main` as that will be needed if `--force` is not passed. I could not identify any other error to catch/raise. 

:bug: Suggestion:
Current code for checking error while running hmmscan function:
```python
    if parallel:
        returncode = subprocess.call(' '.join(cmd), shell=True)
        tmp_fpaths = glob(os.path.join(tmp_dirpath, '*.txt'))
        with open(outfpath, 'w') as out:
            for fp in tmp_fpaths:
                with open(fp) as fh:
                    for line in fh:
                        out.write(line)
        shutil.rmtree(tmp_dirpath)
    else:
        with open(os.devnull, 'w') as STDOUT, open(os.devnull, 'w') as STDERR:
            proc = subprocess.run(cmd, stdout=STDOUT, stderr=STDERR)
        returncode = proc.returncode
    if returncode == 141:
        logger.warning(f'Make sure your hmm profiles are pressed!')
        logger.warning(f'hmmpress -f {hmmdb}')
        logger.error(f'Args:{cmd} ReturnCode:{returncode}')
        raise OSError(f'hmmscan: Args:{cmd} ReturnCode:{returncode}')
    if not os.path.exists(outfpath):
        raise OSError(f'{outfpath} not written.')
    return outfpath
```
I was using hmm database with was not hmmpressed and did not got an error. Suggested change:
```python
    if parallel:
        proc = subprocess.run(' '.join(cmd), shell=True)
        tmp_fpaths = glob(os.path.join(tmp_dirpath, '*.txt'))
        with open(outfpath, 'w') as out:
            for fp in tmp_fpaths:
                with open(fp) as fh:
                    for line in fh:
                        out.write(line)
        shutil.rmtree(tmp_dirpath)
    else:
        with open(os.devnull, 'w') as STDOUT, open(os.devnull, 'w') as STDERR:
            proc = subprocess.run(cmd, stdout=STDOUT, stderr=STDERR)
    try:
        proc.check_returncode()
    except subprocess.CalledProcessError as err:
        logger.warning(f'Make sure your hmm profiles are pressed!')
        logger.warning(f'hmmpress -f {hmmdb}')
        logger.error(f'Args:{cmd} ReturnCode:{proc.returncode}')
        raise err
    if not os.path.exists(outfpath):
        raise OSError(f'{outfpath} not written.')
    return outfpath
```