### PR TITLE
:art: :racehorse: Resolves #55

### DIFF
--- a/autometa/common/external/hmmer.py
+++ b/autometa/common/external/hmmer.py
@@ -28,6 +28,7 @@ import logging
 import os
 import subprocess
 import shutil
+import tempfile
 
 import pandas as pd
 
@@ -79,11 +80,9 @@ def hmmscan(orfs, hmmdb, outfpath, cpus=0, force=False, parallel=True, log=None)
     if parallel:
         outdir = os.path.dirname(os.path.realpath(outfpath))
         outprefix = os.path.splitext(os.path.basename(outfpath))[0]
-        tmpdir = os.path.join(outdir, 'tmp')
-        if not os.path.exists(tmpdir):
-            os.makedirs(tmpdir)
-        tmpfname = '.'.join([outprefix, '{#}', 'txt'])
-        tmpfpath = os.path.join(tmpdir, tmpfname)
+        tmp_dirpath = tempfile.mkdtemp(dir=outdir)
+        __, tmp_fpath = tempfile.mkstemp(
+            suffix=".{#}.txt", prefix=outprefix, dir=tmp_dirpath)
         jobs = f'-j{cpus}'
         cmd = [
             'parallel',
@@ -97,7 +96,7 @@ def hmmscan(orfs, hmmdb, outfpath, cpus=0, force=False, parallel=True, log=None)
             'hmmscan',
             '-o', os.devnull,
             '--tblout',
-            tmpfpath,
+            tmp_fpath,
             hmmdb,
             '-',
             '<', orfs,
@@ -112,16 +111,13 @@ def hmmscan(orfs, hmmdb, outfpath, cpus=0, force=False, parallel=True, log=None)
     logger.debug(f'cmd: {" ".join(cmd)}')
     if parallel:
         returncode = subprocess.call(' '.join(cmd), shell=True)
-        tmpfpaths = glob(os.path.join(tmpdir, '*.txt'))
-        lines = ''
-        for fp in tmpfpaths:
-            with open(fp) as fh:
-                for line in fh:
-                    lines += line
-        out = open(outfpath, 'w')
-        out.write(lines)
-        out.close()
-        shutil.rmtree(tmpdir)
+        tmp_fpaths = glob(os.path.join(tmp_dirpath, '*.txt'))
+        with open(outfpath, 'w') as out:
+            for fp in tmp_fpaths:
+                with open(fp) as fh:
+                    for line in fh:
+                        out.write(line)
+        shutil.rmtree(tmp_dirpath)
     else:
         with open(os.devnull, 'w') as STDOUT, open(os.devnull, 'w') as STDERR:
             proc = subprocess.run(cmd, stdout=STDOUT, stderr=STDERR)
@@ -234,10 +230,30 @@ def filter_markers(infpath, outfpath, cutoffs, orfs=None, force=False):
     return outfpath
 
 
-def main(args):
+def main():
+    import argparse
+    import logging as logger
+    logger.basicConfig(
+        format='%(asctime)s : %(name)s : %(levelname)s : %(message)s',
+        datefmt='%m/%d/%Y %I:%M:%S %p')
+    parser = argparse.ArgumentParser(
+        description='Retrieves markers with provided input assembly')
+    parser.add_argument('orfs', help='</path/to/assembly.orfs.faa>')
+    parser.add_argument('hmmdb', help='</path/to/hmmpressed/hmmdb>')
+    parser.add_argument('cutoffs', help='</path/to/hmm/cutoffs.tsv>')
+    parser.add_argument('hmmscan', help='</path/to/hmmscan.out>')
+    parser.add_argument('markers', help='</path/to/markers.tsv>')
+    parser.add_argument('--log', help='</path/to/parallel.log>')
+    parser.add_argument('--force', help="force overwrite of out filepath",
+                        action='store_true')
+    parser.add_argument('--cpus', help='num cpus to use', default=0, type=int)
+    parser.add_argument(
+        '--parallel', help="Enable GNU parallel", action='store_true')
+    parser.add_argument('--verbose', help="add verbosity", action='store_true')
+    args = parser.parse_args()
+
     if args.verbose:
         logger.setLevel(logger.DEBUG)
-
     try:
         result = hmmscan(
             orfs=args.orfs,
@@ -260,24 +276,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    import argparse
-    import logging as logger
-    logger.basicConfig(
-        format='%(asctime)s : %(name)s : %(levelname)s : %(message)s',
-        datefmt='%m/%d/%Y %I:%M:%S %p')
-    parser = argparse.ArgumentParser(
-        description='Retrieves markers with provided input assembly')
-    parser.add_argument('orfs', help='</path/to/assembly.orfs.faa>')
-    parser.add_argument('hmmdb', help='</path/to/hmmpressed/hmmdb>')
-    parser.add_argument('cutoffs', help='</path/to/hmm/cutoffs.tsv>')
-    parser.add_argument('hmmscan', help='</path/to/hmmscan.out>')
-    parser.add_argument('markers', help='</path/to/markers.tsv>')
-    parser.add_argument('--log', help='</path/to/parallel.log>')
-    parser.add_argument('--force', help="force overwrite of out filepath",
-                        action='store_true')
-    parser.add_argument('--cpus', help='num cpus to use', default=0, type=int)
-    parser.add_argument(
-        '--parallel', help="Enable GNU parallel", action='store_true')
-    parser.add_argument('--verbose', help="add verbosity", action='store_true')
-    args = parser.parse_args()
-    main(args)
+    main()

--- a/autometa/config/environ.py
+++ b/autometa/config/environ.py
@@ -52,25 +52,6 @@ EXECUTABLES = [
 ]
 
 
-def which(program, mode=os.X_OK):
-    """
-    Finds the full path for an executable and checks read permissions exist
-
-    Parameters
-    ----------
-    program : str
-        the program to check
-    mode : path like object, optional
-        permission mask passed to os.access(), by default os.X_OK
-
-    Returns
-    -------
-    str or None
-        the path if it was valid, eg. </path/to/executable/> or None if not
-    """
-    return shutil.which(program)
-
-
 def find_executables():
     """Retrieves executable file paths by looking in Autometa dependent executables.
 
@@ -80,7 +61,7 @@ def find_executables():
         {executable:</path/to/executable>, ...}
 
     """
-    return {exe: which(exe) for exe in EXECUTABLES}
+    return {exe: shutil.which(exe, mode=os.X_OK) for exe in EXECUTABLES}
 
 
 def diamond():
@@ -92,7 +73,7 @@ def diamond():
         version of diamond
 
     """
-    exe = which('diamond')
+    exe = shutil.which('diamond', mode=os.X_OK)
     proc = subprocess.Popen(
         [exe, 'version'],
         stdout=subprocess.PIPE,
@@ -110,7 +91,7 @@ def hmmsearch():
     str
         version of hmmsearch
     """
-    exe = which('hmmsearch')
+    exe = shutil.which('hmmsearch', mode=os.X_OK)
     proc = subprocess.Popen(
         [exe, '-h'],
         stdout=subprocess.PIPE,
@@ -129,7 +110,7 @@ def hmmpress():
     str
         version of hmmpress
     """
-    exe = which('hmmpress')
+    exe = shutil.which('hmmpress', mode=os.X_OK)
     proc = subprocess.Popen(
         [exe, '-h'],
         stdout=subprocess.PIPE,
@@ -148,7 +129,7 @@ def hmmscan():
     str
         version of hmmscan
     """
-    exe = which('hmmscan')
+    exe = shutil.which('hmmscan', mode=os.X_OK)
     proc = subprocess.Popen(
         [exe, '-h'],
         stdout=subprocess.PIPE,
@@ -167,7 +148,7 @@ def prodigal():
     str
         version of prodigal
     """
-    exe = which('prodigal')
+    exe = shutil.which('prodigal', mode=os.X_OK)
     proc = subprocess.Popen(
         [exe, '-v'],
         stdout=subprocess.DEVNULL,
@@ -185,7 +166,7 @@ def bowtie2():
     str
         version of bowtie2
     """
-    exe = which('bowtie2')
+    exe = shutil.which('bowtie2', mode=os.X_OK)
     proc = subprocess.Popen(
         [exe, '--version'],
         stdout=subprocess.PIPE,
@@ -203,7 +184,7 @@ def samtools():
     str
         version of samtools
     """
-    exe = which('samtools')
+    exe = shutil.which('samtools', mode=os.X_OK)
     proc = subprocess.Popen(
         [exe], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = proc.communicate()
@@ -220,7 +201,7 @@ def bedtools():
     str
         version of bedtools
     """
-    exe = which('bedtools')
+    exe = shutil.which('bedtools', mode=os.X_OK)
     proc = subprocess.Popen(
         [exe, '--version'],
         stdout=subprocess.PIPE,
@@ -317,7 +298,7 @@ def configure(config=DEFAULT_CONFIG):
             config.set('environ', executable, found)
             config.set('versions', executable, version)
         user_executable = config.get('environ', executable)
-        if not which(user_executable):
+        if not shutil.which(user_executable, mode=os.X_OK):
             logger.debug(f'{executable}: {found} (version: {version})')
             config.set('environ', executable, found)
             config.set('versions', executable, version)

--- a/autometa/config/environ.py
+++ b/autometa/config/environ.py
@@ -56,8 +56,6 @@ def which(program):
 
     See: https://stackoverflow.com/a/377028
 
-    Returns:
-        The path if it was valid or None if not
 
     Parameters
     ----------
@@ -67,7 +65,8 @@ def which(program):
     Returns
     -------
     str
-        </path/to/executable/> or ''
+        the path if it was valid or an empty string if not
+        eg. </path/to/executable/> or ''
 
     Raises
     -------
@@ -77,7 +76,8 @@ def which(program):
     """
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-    fpath, fname = os.path.split(program)
+    # check to see if program path is given or just the name
+    fpath, __ = os.path.split(program)
     if fpath:
         if is_exe(program):
             return program
@@ -249,13 +249,16 @@ def bedtools():
 
 
 def get_versions(program=None):
-    """Retrieve versions from all required executable dependencies.
+    """
+    Retrieve versions from all required executable dependencies.
     If `program` is provided will only return version for `program`.
+
+    See: https://stackoverflow.com/a/834451/12671809
 
     Parameters
     ----------
-    program : str
-        the program to retrieve the version.
+    program : str, optional
+        the program to retrieve the version, by default None
 
     Returns
     -------
@@ -269,36 +272,26 @@ def get_versions(program=None):
         `program` is not a string
     KeyError
         `program` is not an executable dependency.
-
     """
-    dispatcher = {
-        'prodigal': prodigal,
-        'diamond': diamond,
-        'hmmsearch': hmmsearch,
-        'hmmpress': hmmpress,
-        'hmmscan': hmmscan,
-        'prodigal': prodigal,
-        'bowtie2': bowtie2,
-        'samtools': samtools,
-        'bedtools': bedtools,
-    }
     if program:
-        exe_name = os.path.basename(program)
         if type(program) is not str:
-            raise ValueError(f'program is not string. given:{type(program)}')
-        if exe_name not in dispatcher:
+            raise TypeError(f'program is not string. given:{type(program)}')
+        exe_name = os.path.basename(program)
+        if exe_name not in globals():
             raise KeyError(f'{exe_name} not in executables')
-        return dispatcher[exe_name]()
+        return (globals()[exe_name]())
     versions = {}
     executables = find_executables()
     for exe, found in executables.items():
         if found:
-            version = dispatcher[exe]()
+            # globals()[exe]() accesses the location of the function for that program
+            # eg. location of bedtools(), prodigal(), etc..
+            version = globals()[exe]()
         else:
             logger.warning(f'VersionUnavailable {exe}')
             version = 'ExecutableNotFound'
         versions.update({exe: version})
-    return versions
+    return (versions)
 
 
 def configure(config=DEFAULT_CONFIG):
@@ -365,7 +358,8 @@ def main():
     parser.add_argument('--out',
                         help='</path/to/output/executables.config>')
     args = parser.parse_args()
-    config, satisfied = configure(infpath=args.infpath)
+    user_config = get_config(args.infpath)
+    config, satisfied = configure(config=user_config)
     if not args.out:
         import sys
         sys.exit(0)


### PR DESCRIPTION
- :art: :racehorse: Replaced dispatcher dict by `globals()` [See](https://docs.python.org/3/library/functions.html#globals)
- :art: Changed the location of the checking `TypeError` in `getversions()` function
- :art: :fire: Suggestion: Current code to check if a program is in a the `$PATH` and is executable, is
```python
def which(program):
    def is_exe(fpath):
        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
    # check to see if program path is given or just the name
    fpath, __ = os.path.split(program)
    if fpath:
        if is_exe(program):
            return program
    else:
        for path in os.environ["PATH"].split(os.pathsep):
            exe_file = os.path.join(path, program)
            if is_exe(exe_file):
                return exe_file
    return ''
``` 
We can use `shutil.which()` instead, which is concise and removes unneccesary code. [See](https://docs.python.org/3/library/shutil.html#shutil.which). This does exactly what the above code does and can take program name or program path as input.
Recommendation:
```python
def which(program, mode=os.X_OK):
     return shutil.which(program)
```
The above code will return the file path if the program is in `$PATH` and is executable and None if not. The return is slightly different from what the original code returns, where if the program is not in the `$PATH` or is not an executable it returns an empty string `''`. From my reading of the code returning `None` should not cause any errors, however if we do want to return an empty string in case the program is not in `$PATH` or not executable then we can use this:
```python
def which(program, mode=os.X_OK):
    fpath = shutil.which(program)
    if fpath:
        return fpath
    return ''
```