### PR TITLE
LCA

### DIFF
--- a/autometa/common/kmers.py
+++ b/autometa/common/kmers.py
@@ -349,7 +349,7 @@ def embed(kmers=None, embedded=None, n_components=2, do_pca=True, pca_dimensions
 
         * `sklearn.manifold.TSNE <https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html#sklearn.manifold.TSNE>`_
         * `UMAP <https://umap-learn.readthedocs.io/en/latest/>`_
-        * `tsne.bh_sne` <https://pypi.org/project/tsne/>`_
+        * `tsne.bh_sne <https://pypi.org/project/tsne/>`_
 
     Parameters
     ----------


### PR DESCRIPTION
* fixes #41 
* :fire: Remove static method `aggregate_lcas` as this is _somewhat_ available in prodigal.py
* :art: method `blast2lca` input parameter `blast` is now **required** instead of _optional_.
* :racehorse: Remove redundant reading of `nodes.dmp` in `prepare_tree`
* :memo: Add links to RMQ/LCA datastructures within `prepare_tree` docstring.
* :memo: Fix typo in `kmers.py` resulting in broken hyperlink