### PR TITLE
only try to generate hmm indexes if they do not exist

### DIFF
--- a/pipeline/run_autometa.py
+++ b/pipeline/run_autometa.py
@@ -167,7 +167,8 @@ def make_marker_table(fasta):
 	else:
 		print "Making the marker table with prodigal and hmmscan. This could take a while..."
 		logger.info('Making the marker table with prodigal and hmmscan. This could take a while...')
-		run_command_quiet("hmmpress -f {}".format(hmm_marker_path))
+		if not os.path.exists((hmm_marker_path + ".h3m")):
+                        run_command_quiet("hmmpress -f {}".format(hmm_marker_path))
 		run_command_quiet("{}/make_marker_table.py -a {} -m {} -c {} -o {} -p {}"\
 		.format(pipeline_path, fasta, hmm_marker_path, hmm_cutoffs_path, output_path, processors))
 	return output_path


### PR DESCRIPTION
This fix is one in a step to supporting global system install on HPCC with read-only access to marker folder