### PR TITLE
Only ignore /lib at top level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
The nf-core template has a `lib` directory.  This commit changes .gitignore to only ignore `lib` at the top level directory. 