### PR TITLE
Add nextflow config for testing 2.0

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,0 +1,11 @@
+manifest {
+    author = "Jason C. Kwan Lab"
+    defaultBranch = "dev"
+    name = "autometa"
+    homePage = "https://github.com/KwanLab/Autometa"
+    description = "Autometa: Automated Extraction of Microbial Genomes from Shotgun Metagenomes"
+    mainScript = "main.nf"
+    doi = "https://doi.org/10.1093/nar/gkz148"
+    version = "2.0.0"
+    nextflowVersion = "21.04+"
+}


### PR DESCRIPTION
Nextflow won't pull a pipeline from GitHub unless these files exist on the main branch. These are minimal placeholders so people can more closely follow the new documentation when trying out the new Nextflow pipeline.