### PR TITLE
Nextflow documentation

### DIFF
--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -2,131 +2,145 @@
 Running Autometa
 ================
 
+
+Why nextflow?
+=============
+
+Nextflow helps Autometa produce reproducible results while allowing the pipeline to scale across different platforms and hardware.
+
+System Requirements
+===================
+
+Currently the nextflow pipeline requires Docker so it must be installed on your system. If you don't have Docker installed you can install it from `docs.docker.com <https://docs.docker.com/get-docker>`_. We plan on removing this dependency in future versions, so other dependency managers (e.g. Conda, Singularity, etc) can be used.
+
+Nextflow runs on any Posix compatible system. Detailed system requirements can be found in the nextflow documentation `here <https://www.nextflow.io/docs/latest/getstarted.html#requirements>`_
+
+Nextflow (required) and nf-core tools (optional but highly recommended) installation will be discussed in :ref:`install-nextflow-nfcore-with-conda`.
+
+
 Data preparation
 ================
 
-Before you run Autometa, you need to have assembled your shotgun metagenome. The following workflow is recommended:
+Autometa takes contigs as input, so you need to have previously assembled your shotgun metagenome. The following workflow is recommended:
 
 #. Trim adapter sequences from the reads. We prefer to use Trimmomatic_, but you can go ahead and use any tool of your preference.
 #. Quality check of reads to make sure that the adapters have been removed, we use FastQC_ for this.
 #. Assemble the trimmed reads. We recommend using MetaSPAdes which is a part of the SPAdes_ package to assemble the trimmed reads but you can use any other assembler as well.
 #. An optional thing to do here would be to check the quality of your assembly as well. This would give you a variety of assembly statistics one of which is N50 which will be useful in selecting the cutoff value during the Autometa length-filter step. We tend to use metaQuast_ for this (use ``--min-contig 1`` option to get an accurate N50).
 
+
 .. TODO: SPAdes info is for python version, currently the Nextflow version assumes everything is from SPAdes. It's not clear how coverage is used.
+    .. note::
 
-.. note::
+        If you use SPAdes then Autometa can use the k-mer coverage information in the contig names. If you have used any other assembler, then you first have to make a coverage table.
 
-    If you use SPAdes then Autometa can use the k-mer coverage information in the contig names. If you have used any other assembler, then you first have to make a coverage table.
-
-    Fortunately, Autometa can construct this table for you with: ``autometa-coverage``. Use ``--help`` to get the complete usage.
-
-Nextflow walkthrough
-====================
-
-Why nextflow
-------------
-
-Nextflow helps Autometa produce reproducible results while allowing the pipeline to scale across different platforms and hardware.
+        Fortunately, Autometa can construct this table for you with: ``autometa-coverage``. Use ``--help`` to get the complete usage.
 
 
-System Requirements
--------------------
+Basic
+=====
 
-Nextflow 
+While the Autometa Nextflow pipeline can be run using Nextflow directly, we designed it using nf-core standards and templating to provide an easier user experience through use of the nf-core "tools" python library. 
+The directions below demonstrate using a minimal Conda environment to install Nextflow and nf-core tools and run the Autometa pipeline. 
 
-Currently the nextflow pipeline only works with Docker so Docker must be installed on your system `Get Docker <https://docs.docker.com/get-docker>`_. We do plan on removing this dependency on Docker.
+.. _install-nextflow-nfcore-with-conda:
 
-Nextflow runs on any Linux compatible system or MacOS with Java installed. 
+Installing Nextflow and nf-core tools with Conda
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+If you have not previously installed/used Conda, you can get it using the OS-appropriate Miniconda installer here: `<https://docs.conda.io/en/latest/miniconda.html>`_
 
-Quick Start
-------------
-
-Installation
-^^^^^^^^^^^^
-Using `conda <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_ install nf-core and nextflow into an environment (here called 'autometa-nf')
+Running the following command will create a minimal Conda environment named "autometa-nf", and install Nextflow and nf-core tools.
 
 .. code-block:: bash
 
-    curl -s https://raw.githubusercontent.com/KwanLab/Autometa/nfcore/environment.yml | conda env create
+    conda env create --file=https://raw.githubusercontent.com/KwanLab/Autometa/nfcore/environment.yml
+
+If you receive the message...
+
+.. code-block:: bash
+
+    CondaValueError: prefix already exists:
+
+...it means you have already created the environment. If you want to overwrite/update the environment then add the force flag to the end of the command: :code:`conda env create... --force`
 
 
-Once it finishes installing be sure to active the environment:
+Once Conda has finished creating the environment be sure to active it:
 
 .. code-block:: bash
 
     conda activate autometa-nf
 
-After launching for the first time (next section), the pipeline will download and install dependencies as required (either with Docker or Conda, as selected). 
-
-Optional: If you want to use nextflow directly and not through nf-core tools, download the pipeline from GitHub using nextflow.
-
-.. code-block:: bash
-
-    nextflow pull KwanLab/Autometa -r main
-
     
+Launching Autometa using nf-core tools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Launching Autometa with nf-core tools
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Run the pipeline using the command below. 
+Download/Launch the Autometa Nextflow pipeline using nf-core tools. The stable version will always be the "main" git branch. To use an in-development git branch switch "main" with the name of the branch. After the pipeline downloads nf-core will start the pipeline launch process.
 
 .. code-block:: bash
 
-    nf-core launch KwanLab/Autometa
+    nf-core launch KwanLab/Autometa -r main
 
 You will then be asked to choose "Web based" or "Command line" in order to select/provide options. While it is possible to use the command line version, it is preferred and easier to use the web-based GUI.
 Use the arrow keys to select one or the other and then press return/enter.
 
 
-Set autometa parameters with web based GUI
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Set autometa parameters with nf-core tools web based GUI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The GUI will present all available parameters, though some extra parameters may be hidden. Toggle "Show hidden params" on the right side of the page to reveal hidden parameters.
+The GUI will present all available parameters, though some extra parameters may be hidden (these can be revealed by selecting "Show hidden params" on the right side of the page).
 
-The only mandatory parameters are :code:`--input` which is the path to your input metagenome's nucleotide FASTA file, and :code:`-profile`.
-
-The most common options for :code:`-profile` are 
-
-* **standard**: runs all process jobs locally. If you use slurm, don't use this.
-* **slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm:` before using
-
-An example input for locally-executed jobs would be 
-
-:code:`-profile`: standard,docker
-
-An example input for slurm-executed jobs would be 
-
-:code:`-profile`: basic_slurm,docker
-
+* Parameters to set every time
+    - :code:`--input`: the path to your input metagenome's nucleotide FASTA file
+    - :code:`-profile`: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
+        - **standard** (default): runs all process jobs locally.
+        - **slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm:` before using
 
 Running the pipeline
 ^^^^^^^^^^^^^^^^^^^^
-
 After you are finished double-checking your parameter settings, click "Launch" at the top right of web based GUI page, or "Launch workflow" at the bottom of the page. After returning to the terminal you should be provided the option :code:`Do you want to run this command now?  [y/n]`  enter :code:`y` to begin the pipeline.
 
+.. note::
 
-Advanced Nextflow
------------------
+    This process will lead to nf-core tools creating a file named :code:`nf-params.json`. This file contains your specified parameters that differed from the pipeline's defaults. This file can be modified by hand and shared to allow even easier configuration/sharing of settings (e.g. among members within a lab who use the same computing system).
+
+    Additionally all Autometa specific pipeline parameters can be used as command line arguments using the :code:`nextflow run ...` command by prepending the parameter name with two hyphens (e.g. :code:`--input`)
+
+
+Advanced
+========
+
+Parallel computing and computer resource allotment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+While you might want to provide Autometa all the compute resources available in order to get results faster, that may or may not actually achieve the fastest run time.
+
+Within the Autometa pipeline, parallelization happens two ways: 1) by providing all the contigs at once to software that handles parallelization internally; 2) by splitting the input FASTA into batches of contigs which are provided in parallel to non-parallelized software.
+
+In regards to the first method: The Autometa pipeline will try and use all resources available to individual pipeline modules. Each module has been pre-assigned resource allotments via a low/medium/high tag. This means that even if you don't select for the pipeline to run in parallel some modules (e.g. DIAMOND BLAST) may use multiple cores. The max number of CPUs that any single module can use is defined with the :code:`--max_cpus` option (default: 4). You can also set :code:`--max_memory` (default: 16GB) and :code:`--max_time` (default: 240h).
+
+In regards to the 2nd method: The Autometa pipeline will split the input metagenome FASTA file into the specified number of files which can be set by providing an integer value to the option: :code:`--num_splits` (default: :code:`1`- no splits, not run in parallel). Choosing the largest number of parallel processes possible may not provide largest gain in performance and a good rule would be to not exceed the number of avaliable cores.
 
 
 Multiple Inputs
 ^^^^^^^^^^^^^^^
 
-You can also input multiple assemblies at once with the help of wildcards. In the below example all the files with extension ".fna" would be taken as input by nextflow_.
+You can input multiple assemblies at once using path wildcards. In the below example all the files with extension ".fna" would be taken as input by nextflow. The pipeline will organize/name outputs based on these filenames.
 :code:`--input /tutorial/test_data/*.fna`
 
-Database directory
-^^^^^^^^^^^^^^^^^^
+Databases
+^^^^^^^^^
 
 .. todo::
 
 Autometa uses the following NCBI databses throughout its pipeline:
 
-- Non-redundant `nr database <ftp://ftp.ncbi.nlm.nih.gov/blast/db/FASTA/nr.gz>`_
-- `prot.accession2taxid.gz <ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz>`_
-- *nodes.dmp*, *names.dmp* and *merged.dmp* from `taxdump tarball <ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz>`_ 
+- Non-redundant nr database
+    - `ftp.ncbi.nlm.nih.gov/blast/db/FASTA/nr.gz <https://ftp.ncbi.nlm.nih.gov/blast/db/FASTA>`_
+- prot.accession2taxid.gz
+    - `ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz <https://ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/>`_
+- *nodes.dmp*, *names.dmp* and *merged.dmp* 
+  - Found in within `ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz <ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy>`_ 
 
 If you are running autometa for the first time you'll have to download these databases. Use ``autometa-update-databases --update-ncbi``. This will download the databases to the default path. You can check the default paths using ``autometa-config --print``. If you need to change the default download directory you can use ``autometa-config --section databases --option ncbi --value <path/to/new/ncbi_database_directory>``. See ``autometa-update-databases -h`` and ``autometa-config-h`` for full list of options.
 

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -48,7 +48,7 @@ Using `conda <https://conda.io/projects/conda/en/latest/user-guide/install/index
 
 .. code-block:: bash
 
-    conda create -c conda-forge -c bioconda --name autometa-nf python>=3.7 nf-core>=2 nextflow>=21.04.0 -y
+    curl -s https://raw.githubusercontent.com/KwanLab/Autometa/nfcore/environment.yml | conda env create
 
 
 Once it finishes installing be sure to active the environment:

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -45,12 +45,11 @@ The following workflow is recommended:
    * We usually use metaQuast_ for this (use ``--min-contig 1`` option to get an accurate N50).
 
 
-.. TODO: SPAdes info is for python version, currently the Nextflow version assumes everything is from SPAdes. It's not clear how coverage is used.
-    .. note::
+.. note::
 
-        If you use SPAdes then Autometa can use the k-mer coverage information in the contig names. If you have used any other assembler, then you first have to make a coverage table.
+    If you use SPAdes then Autometa can use the k-mer coverage information in the contig names. If you have used any other assembler, then you first have to make a coverage table.
 
-        Fortunately, Autometa can construct this table for you with: ``autometa-coverage``. Use ``--help`` to get the complete usage.
+    Fortunately, Autometa can construct this table for you with: ``autometa-coverage``. Use ``--help`` to get the complete usage.
 
 
 Basic
@@ -180,8 +179,6 @@ would be taken as input by nextflow. The pipeline will organize/name outputs bas
 
 Databases
 ^^^^^^^^^
-
-.. todo::
 
 Autometa uses the following NCBI databases throughout its pipeline:
 
@@ -319,11 +316,6 @@ the repository and then run nextflow directly from the scripts as below:
     # Then run nextflow
     nextflow run $HOME/Autometa/nextflow
 
-Without docker
-^^^^^^^^^^^^^^
-
-.. todo::
-
 Useful options
 ^^^^^^^^^^^^^^
 
@@ -346,15 +338,15 @@ Execution Report
 
 After running nextflow you can see the execution statistics of your autometa run, including the time taken, CPUs used, 
 RAM used, etc separately for each process. Nextflow would generate a summary report, a timeline report and a trace report 
-automatically for you in the ``"${params.tracedir}/pipeline_info`` directory (``"${params.tracedir}`` defaults to 
+automatically for you in the ``${params.tracedir}/pipeline_info`` directory (``${params.tracedir}`` defaults to 
 ``autometa_tracedir``). You can read more about this in the 
 `nextflow docs on execution reports <https://www.nextflow.io/docs/latest/tracing.html#execution-report>`_. 
 
-Workflow Visualized
-^^^^^^^^^^^^^^^^^^^
+Visualizing the Workflow 
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can also visualize the entire workflow ie. create the DAG from the written DOT file. Install 
-`Graphviz <https://graphviz.org/>`_ (``conda install -c anaconda graphviz``) and do ``dot -Tpng < pipeline_info/autometa-dot > autometa-dag.png`` to get the 
+You can visualize the entire workflow ie. create the directed acyclic graph (DAG) of processes from the written DOT file. First install 
+`Graphviz <https://graphviz.org/>`_ (``conda install -c anaconda graphviz``) then do ``dot -Tpng < pipeline_info/autometa-dot > autometa-dag.png`` to get the 
 in the ``png`` format.
 
 Configure nextflow with your 'executor'
@@ -410,9 +402,6 @@ Create a new image by navigating to the top Autometa directory and running ``mak
 Autometa Docker image, tagged with the name of the current Git branch. 
 
 To use this tagged version (or any other Autometa image tag) add the argument ``--autometa_image tag_name`` to the nextflow run command
-
-.. todo:: Below python specific maybe there should be two "running..." files, one for nextflow and one for python?
-
 
 
 Running modules

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -11,7 +11,7 @@ Nextflow helps Autometa produce reproducible results while allowing the pipeline
 System Requirements
 ===================
 
-Currently the nextflow pipeline requires Docker so it must be installed on your system. If you don't have Docker installed you can install it from `docs.docker.com <https://docs.docker.com/get-docker>`_. We plan on removing this dependency in future versions, so other dependency managers (e.g. Conda, Singularity, etc) can be used.
+Currently the nextflow pipeline requires Docker so it must be installed on your system. If you don't have Docker installed you can install it from `docs.docker.com <https://docs.docker.com/get-docker>`_. We plan on removing this dependency in future versions, so that other dependency managers (e.g. Conda, Singularity, etc) can be used.
 
 Nextflow runs on any Posix compatible system. Detailed system requirements can be found in the nextflow documentation `here <https://www.nextflow.io/docs/latest/getstarted.html#requirements>`_
 
@@ -23,10 +23,21 @@ Data preparation
 
 Autometa takes contigs as input, so you need to have previously assembled your shotgun metagenome. The following workflow is recommended:
 
-#. Trim adapter sequences from the reads. We prefer to use Trimmomatic_, but you can go ahead and use any tool of your preference.
-#. Quality check of reads to make sure that the adapters have been removed, we use FastQC_ for this.
-#. Assemble the trimmed reads. We recommend using MetaSPAdes which is a part of the SPAdes_ package to assemble the trimmed reads but you can use any other assembler as well.
-#. An optional thing to do here would be to check the quality of your assembly as well. This would give you a variety of assembly statistics one of which is N50 which will be useful in selecting the cutoff value during the Autometa length-filter step. We tend to use metaQuast_ for this (use ``--min-contig 1`` option to get an accurate N50).
+#. Trim adapter sequences from the reads. 
+
+   * We usually use Trimmomatic_.
+
+#. Quality check of reads to make sure that the adapters have been removed.
+
+   * We usually use FastQC_.
+
+#. Assemble the trimmed reads. 
+
+   * We usually use MetaSPAdes which is a part of the SPAdes_ package.
+
+#. An optional thing to do here would be to check the quality of your assembly as well. This would give you a variety of assembly statistics one of which is N50 which will be useful in selecting the cutoff value during the Autometa length-filter step. 
+   
+   * We usually use metaQuast_ for this (use ``--min-contig 1`` option to get an accurate N50).
 
 
 .. TODO: SPAdes info is for python version, currently the Nextflow version assumes everything is from SPAdes. It's not clear how coverage is used.
@@ -41,20 +52,20 @@ Basic
 =====
 
 While the Autometa Nextflow pipeline can be run using Nextflow directly, we designed it using nf-core standards and templating to provide an easier user experience through use of the nf-core "tools" python library. 
-The directions below demonstrate using a minimal Conda environment to install Nextflow and nf-core tools and run the Autometa pipeline. 
+The directions below demonstrate using a minimal Conda environment to install Nextflow and nf-core tools and then running the Autometa pipeline. 
 
 .. _install-nextflow-nfcore-with-conda:
 
 Installing Nextflow and nf-core tools with Conda
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you have not previously installed/used Conda, you can get it using the OS-appropriate Miniconda installer here: `<https://docs.conda.io/en/latest/miniconda.html>`_
+If you have not previously installed/used Conda, you can get it using the Miniconda installer appropriate to your system, here: `<https://docs.conda.io/en/latest/miniconda.html>`_
 
-Running the following command will create a minimal Conda environment named "autometa-nf", and install Nextflow and nf-core tools.
+After installing conda, running the following command will create a minimal Conda environment named "autometa-nf", and install Nextflow and nf-core tools.
 
 .. code-block:: bash
 
-    conda env create --file=https://raw.githubusercontent.com/KwanLab/Autometa/nfcore/environment.yml
+    conda env create --file=https://raw.githubusercontent.com/KwanLab/Autometa/main/environment.yml
 
 If you receive the message...
 
@@ -75,13 +86,13 @@ Once Conda has finished creating the environment be sure to active it:
 Launching Autometa using nf-core tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Download/Launch the Autometa Nextflow pipeline using nf-core tools. The stable version will always be the "main" git branch. To use an in-development git branch switch "main" with the name of the branch. After the pipeline downloads nf-core will start the pipeline launch process.
+Download/Launch the Autometa Nextflow pipeline using nf-core tools. The stable version of Autometa will always be the "main" git branch. To use an in-development git branch switch "main" in the command(s) with the name of the desired branch. After the pipeline downloads nf-core will start the pipeline launch process.
 
 .. code-block:: bash
 
     nf-core launch KwanLab/Autometa -r main
 
-You will then be asked to choose "Web based" or "Command line" in order to select/provide options. While it is possible to use the command line version, it is preferred and easier to use the web-based GUI.
+You will then be asked to choose "Web based" or "Command line" for selecting/providing options. While it is possible to use the command line version, it is preferred and easier to use the web-based GUI.
 Use the arrow keys to select one or the other and then press return/enter.
 
 
@@ -93,7 +104,7 @@ The GUI will present all available parameters, though some extra parameters may 
 * Parameters to set every time
     - :code:`--input`: the path to your input metagenome's nucleotide FASTA file
     - :code:`-profile`: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
-        - **standard** (default): runs all process jobs locally.
+        - **standard** (default): runs all process jobs locally, (currently this requires Docker).
         - **slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm:` before using
 
 Running the pipeline
@@ -102,9 +113,9 @@ After you are finished double-checking your parameter settings, click "Launch" a
 
 .. note::
 
-    This process will lead to nf-core tools creating a file named :code:`nf-params.json`. This file contains your specified parameters that differed from the pipeline's defaults. This file can be modified by hand and shared to allow even easier configuration/sharing of settings (e.g. among members within a lab who use the same computing system).
+    This process will lead to nf-core tools creating a file named :code:`nf-params.json`. This file contains your specified parameters that differed from the pipeline's defaults. This file can also be modified by hand and/or shared to allow reproducible configuration/sharing of settings (e.g. among members within a lab who use the same computing system).
 
-    Additionally all Autometa specific pipeline parameters can be used as command line arguments using the :code:`nextflow run ...` command by prepending the parameter name with two hyphens (e.g. :code:`--input`)
+    Additionally all Autometa specific pipeline parameters can be used as command line arguments using the :code:`nextflow run ...` command by prepending the parameter name with two hyphens (e.g. :code:`--input "my/file/path/contigs"`)
 
 
 Advanced
@@ -117,9 +128,9 @@ While you might want to provide Autometa all the compute resources available in 
 
 Within the Autometa pipeline, parallelization happens two ways: 1) by providing all the contigs at once to software that handles parallelization internally; 2) by splitting the input FASTA into batches of contigs which are provided in parallel to non-parallelized software.
 
-In regards to the first method: The Autometa pipeline will try and use all resources available to individual pipeline modules. Each module has been pre-assigned resource allotments via a low/medium/high tag. This means that even if you don't select for the pipeline to run in parallel some modules (e.g. DIAMOND BLAST) may use multiple cores. The max number of CPUs that any single module can use is defined with the :code:`--max_cpus` option (default: 4). You can also set :code:`--max_memory` (default: 16GB) and :code:`--max_time` (default: 240h).
+In regards to the first method: The Autometa pipeline will try and use all resources available to individual pipeline modules. Each module/process has been pre-assigned resource allotments via a low/medium/high tag. This means that even if you don't select for the pipeline to run in parallel some modules (e.g. DIAMOND BLAST) may still use multiple cores. The maximum number of CPUs that any single module can use is defined with the :code:`--max_cpus` option (default: 4). You can also set :code:`--max_memory` (default: 16GB) and/or :code:`--max_time` (default: 240h). :code:`--max_time` refers to the maximum time each process is allowed to run, not the execution time for the the entire pipeline.
 
-In regards to the 2nd method: The Autometa pipeline will split the input metagenome FASTA file into the specified number of files which can be set by providing an integer value to the option: :code:`--num_splits` (default: :code:`1`- no splits, not run in parallel). Choosing the largest number of parallel processes possible may not provide largest gain in performance and a good rule would be to not exceed the number of avaliable cores.
+In regards to the 2nd method: The Autometa pipeline will split the input metagenome FASTA file into the specified number of files which can be set by providing an integer value to the option: :code:`--num_splits` (default: :code:`1`- no splits, not run in parallel). Choosing the largest number of parallel processes possible may not provide largest gain in performance and a good rule would be to not exceed the number of avaliable cores available.
 
 
 Multiple Inputs

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -11,9 +11,13 @@ Nextflow helps Autometa produce reproducible results while allowing the pipeline
 System Requirements
 ===================
 
-Currently the nextflow pipeline requires Docker so it must be installed on your system. If you don't have Docker installed you can install it from `docs.docker.com <https://docs.docker.com/get-docker>`_. We plan on removing this dependency in future versions, so that other dependency managers (e.g. Conda, Singularity, etc) can be used.
+Currently the nextflow pipeline requires Docker so it must be installed on your system. 
+If you don't have Docker installed you can install it from `docs.docker.com/get-docker <https://docs.docker.com/get-docker>`_.
+We plan on removing this dependency in future versions, so that other dependency managers 
+(e.g. Conda, Singularity, etc) can be used.
 
-Nextflow runs on any Posix compatible system. Detailed system requirements can be found in the nextflow documentation `here <https://www.nextflow.io/docs/latest/getstarted.html#requirements>`_
+Nextflow runs on any Posix compatible system. Detailed system requirements 
+can be found in the `nextflow documentation <https://www.nextflow.io/docs/latest/getstarted.html#requirements>`_
 
 Nextflow (required) and nf-core tools (optional but highly recommended) installation will be discussed in :ref:`install-nextflow-nfcore-with-conda`.
 
@@ -21,7 +25,8 @@ Nextflow (required) and nf-core tools (optional but highly recommended) installa
 Data preparation
 ================
 
-Autometa takes contigs as input, so you need to have previously assembled your shotgun metagenome. The following workflow is recommended:
+Autometa takes contigs as input, so you need to have previously assembled your shotgun metagenome. 
+The following workflow is recommended:
 
 #. Trim adapter sequences from the reads. 
 
@@ -51,21 +56,25 @@ Autometa takes contigs as input, so you need to have previously assembled your s
 Basic
 =====
 
-While the Autometa Nextflow pipeline can be run using Nextflow directly, we designed it using nf-core standards and templating to provide an easier user experience through use of the nf-core "tools" python library. 
-The directions below demonstrate using a minimal Conda environment to install Nextflow and nf-core tools and then running the Autometa pipeline. 
+While the Autometa Nextflow pipeline can be run using Nextflow directly, we designed 
+it using nf-core standards and templating to provide an easier user experience through 
+use of the nf-core "tools" python library. The directions below demonstrate using a minimal 
+Conda environment to install Nextflow and nf-core tools and then running the Autometa pipeline. 
 
 .. _install-nextflow-nfcore-with-conda:
 
 Installing Nextflow and nf-core tools with Conda
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you have not previously installed/used Conda, you can get it using the Miniconda installer appropriate to your system, here: `<https://docs.conda.io/en/latest/miniconda.html>`_
+If you have not previously installed/used Conda, you can get it using the 
+Miniconda installer appropriate to your system, here: `<https://docs.conda.io/en/latest/miniconda.html>`_
 
-After installing conda, running the following command will create a minimal Conda environment named "autometa-nf", and install Nextflow and nf-core tools.
+After installing conda, running the following command will create a minimal
+ Conda environment named "autometa-nf", and install Nextflow and nf-core tools.
 
 .. code-block:: bash
 
-    conda env create --file=https://raw.githubusercontent.com/KwanLab/Autometa/main/environment.yml
+    conda env create --file=https://raw.githubusercontent.com/KwanLab/Autometa/dev/environment.yml
 
 If you receive the message...
 
@@ -73,10 +82,12 @@ If you receive the message...
 
     CondaValueError: prefix already exists:
 
-...it means you have already created the environment. If you want to overwrite/update the environment then add the force flag to the end of the command: :code:`conda env create... --force`
+...it means you have already created the environment. If you want to overwrite/update 
+the environment then add the force flag to the end of the 
+command: :code:`conda env create... --force`
 
 
-Once Conda has finished creating the environment be sure to active it:
+Once Conda has finished creating the environment be sure to activate it:
 
 .. code-block:: bash
 
@@ -86,36 +97,51 @@ Once Conda has finished creating the environment be sure to active it:
 Launching Autometa using nf-core tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Download/Launch the Autometa Nextflow pipeline using nf-core tools. The stable version of Autometa will always be the "main" git branch. To use an in-development git branch switch "main" in the command(s) with the name of the desired branch. After the pipeline downloads nf-core will start the pipeline launch process.
+Download/Launch the Autometa Nextflow pipeline using nf-core tools. 
+The stable version of Autometa will always be the "main" git branch. 
+To use an in-development git branch switch "main" in the command with 
+the name of the desired branch. After the pipeline downloads nf-core will 
+start the pipeline launch process.
 
 .. code-block:: bash
 
     nf-core launch KwanLab/Autometa -r main
 
-You will then be asked to choose "Web based" or "Command line" for selecting/providing options. While it is possible to use the command line version, it is preferred and easier to use the web-based GUI.
+You will then be asked to choose "Web based" or "Command line" for selecting/providing options.
+While it is possible to use the command line version, it is preferred and easier to use the web-based GUI.
 Use the arrow keys to select one or the other and then press return/enter.
 
 
 Set autometa parameters with nf-core tools web based GUI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The GUI will present all available parameters, though some extra parameters may be hidden (these can be revealed by selecting "Show hidden params" on the right side of the page).
+The GUI will present all available parameters, though some extra 
+parameters may be hidden (these can be revealed by selecting 
+"Show hidden params" on the right side of the page).
 
 * Parameters to set every time
-    - :code:`--input`: the path to your input metagenome's nucleotide FASTA file
-    - :code:`-profile`: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
+    - ``--input``: the path to your input metagenome's nucleotide FASTA file
+    - ``-profile``: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
         - **standard** (default): runs all process jobs locally, (currently this requires Docker).
-        - **slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm:` before using
+        - **slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm` before using
 
 Running the pipeline
 ^^^^^^^^^^^^^^^^^^^^
-After you are finished double-checking your parameter settings, click "Launch" at the top right of web based GUI page, or "Launch workflow" at the bottom of the page. After returning to the terminal you should be provided the option :code:`Do you want to run this command now?  [y/n]`  enter :code:`y` to begin the pipeline.
+After you are finished double-checking your parameter settings, click "Launch" 
+at the top right of web based GUI page, or "Launch workflow" at the bottom of 
+the page. After returning to the terminal you should be provided the option 
+:code:`Do you want to run this command now?  [y/n]`  enter :code:`y` to begin the pipeline.
 
 .. note::
 
-    This process will lead to nf-core tools creating a file named :code:`nf-params.json`. This file contains your specified parameters that differed from the pipeline's defaults. This file can also be modified by hand and/or shared to allow reproducible configuration/sharing of settings (e.g. among members within a lab who use the same computing system).
+    This process will lead to nf-core tools creating a file named :code:`nf-params.json`. 
+    This file contains your specified parameters that differed from the pipeline's defaults.
+    This file can also be manually modified and/or shared to allow reproducible configuration
+    of settings (e.g. among members within a lab sharing the same server).
 
-    Additionally all Autometa specific pipeline parameters can be used as command line arguments using the :code:`nextflow run ...` command by prepending the parameter name with two hyphens (e.g. :code:`--input "my/file/path/contigs"`)
+    Additionally all Autometa specific pipeline parameters can be used as command line arguments
+    using the :code:`nextflow run ...` command by prepending the parameter name with two hyphens
+    (e.g. :code:`--input "my/file/path/assembly.fasta"`)
 
 
 Advanced
@@ -124,19 +150,32 @@ Advanced
 Parallel computing and computer resource allotment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-While you might want to provide Autometa all the compute resources available in order to get results faster, that may or may not actually achieve the fastest run time.
+While you might want to provide Autometa all the compute resources available in order to get results 
+faster, that may or may not actually achieve the fastest run time.
 
-Within the Autometa pipeline, parallelization happens two ways: 1) by providing all the contigs at once to software that handles parallelization internally; 2) by splitting the input FASTA into batches of contigs which are provided in parallel to non-parallelized software.
+Within the Autometa pipeline, parallelization happens two ways: 1) by providing all the contigs at once 
+to software that handles parallelization internally; 2) by splitting the input FASTA into batches of contigs 
+which are provided in parallel to non-parallelized software.
 
-In regards to the first method: The Autometa pipeline will try and use all resources available to individual pipeline modules. Each module/process has been pre-assigned resource allotments via a low/medium/high tag. This means that even if you don't select for the pipeline to run in parallel some modules (e.g. DIAMOND BLAST) may still use multiple cores. The maximum number of CPUs that any single module can use is defined with the :code:`--max_cpus` option (default: 4). You can also set :code:`--max_memory` (default: 16GB) and/or :code:`--max_time` (default: 240h). :code:`--max_time` refers to the maximum time each process is allowed to run, not the execution time for the the entire pipeline.
+In regards to the first method: The Autometa pipeline will try and use all resources available to individual 
+pipeline modules. Each module/process has been pre-assigned resource allotments via a low/medium/high tag. 
+This means that even if you don't select for the pipeline to run in parallel some modules (e.g. DIAMOND BLAST) 
+may still use multiple cores. The maximum number of CPUs that any single module can use is defined with 
+the :code:`--max_cpus` option (default: 4). You can also set :code:`--max_memory` (default: 16GB) and/or 
+:code:`--max_time` (default: 240h). :code:`--max_time` refers to the maximum time *each process* is allowed to run, 
+*not* the execution time for the the entire pipeline.
 
-In regards to the 2nd method: The Autometa pipeline will split the input metagenome FASTA file into the specified number of files which can be set by providing an integer value to the option: :code:`--num_splits` (default: :code:`1`- no splits, not run in parallel). Choosing the largest number of parallel processes possible may not provide largest gain in performance and a good rule would be to not exceed the number of avaliable cores available.
+In regards to the 2nd method: The Autometa pipeline will split the input metagenome FASTA file into the specified 
+number of files which can be set by providing an integer value to the option: :code:`--num_splits` (default: 
+:code:`1`- no splits, not run in parallel). Choosing the largest number of parallel processes possible may not provide 
+largest gain in performance and a good rule would be to not exceed the number of avaliable cores available.
 
 
 Multiple Inputs
 ^^^^^^^^^^^^^^^
 
-You can input multiple assemblies at once using path wildcards. In the below example all the files with extension ".fna" would be taken as input by nextflow. The pipeline will organize/name outputs based on these filenames.
+You can input multiple assemblies at once using path wildcards. In the below example all the files with extension ".fna" 
+would be taken as input by nextflow. The pipeline will organize/name outputs based on these filenames.
 :code:`--input /tutorial/test_data/*.fna`
 
 Databases
@@ -144,24 +183,29 @@ Databases
 
 .. todo::
 
-Autometa uses the following NCBI databses throughout its pipeline:
+Autometa uses the following NCBI databases throughout its pipeline:
 
 - Non-redundant nr database
-    - `ftp.ncbi.nlm.nih.gov/blast/db/FASTA/nr.gz <https://ftp.ncbi.nlm.nih.gov/blast/db/FASTA>`_
+    - `ftp.ncbi.nlm.nih.gov/blast/db/FASTA/nr.gz <https://ftp.ncbi.nlm.nih.gov/blast/db/FASTA/nr.gz>`_
 - prot.accession2taxid.gz
-    - `ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz <https://ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/>`_
-- *nodes.dmp*, *names.dmp* and *merged.dmp* 
-  - Found in within `ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz <ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy>`_ 
+    - `ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz <https://ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz>`_
+- nodes.dmp, names.dmp and merged.dmp - Found within
+    - `ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz <ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz>`_ 
 
-If you are running autometa for the first time you'll have to download these databases. Use ``autometa-update-databases --update-ncbi``. This will download the databases to the default path. You can check the default paths using ``autometa-config --print``. If you need to change the default download directory you can use ``autometa-config --section databases --option ncbi --value <path/to/new/ncbi_database_directory>``. See ``autometa-update-databases -h`` and ``autometa-config-h`` for full list of options.
+If you are running autometa for the first time you'll have to download these databases. 
+You may use ``autometa-update-databases --update-ncbi``. This will download the databases to the default path. You can check 
+the default paths using ``autometa-config --print``. If you need to change the default download directory you can use 
+``autometa-config --section databases --option ncbi --value <path/to/new/ncbi_database_directory>``. 
+See ``autometa-update-databases -h`` and ``autometa-config -h`` for full list of options.
 
-In your ``parameters.config`` file you also need to specify the directory where the different databases are present. Make sure that the directory path contains the following databases:
+In your ``parameters.config`` file you also need to specify the directory where the different databases are present. 
+Make sure that the directory path contains the following databases:
 
 - Diamond formatted nr file => nr.dmnd
 - Extracted files from tarball taxdump.tar.gz
 - prot.accession2taxid.gz
 
-.. code-block:: bash
+.. code-block:: groovy
 
     // Find this section of code in parameters.config
     // Update this path to folder with all NCBI databases
@@ -170,15 +214,21 @@ In your ``parameters.config`` file you also need to specify the directory where 
 CPUs, Memory, Disk
 ^^^^^^^^^^^^^^^^^^
 
-Like nf-core pipelines, we have set some automatic defaults for Autometa's processes. These are dynamic and each process will try a second attempt using more resources if the first fails due to resources. Resources are always capped by the parameters (show with defaults):
+.. note::
+    
+    Like nf-core pipelines, we have set some automatic defaults for Autometa's processes. These are dynamic and each 
+    process will try a second attempt using more resources if the first fails due to resources. Resources are always 
+    capped by the parameters (show with defaults):
+
  - :code:`-max_cpus = 2` 
  - :code:`-max_memory = 6.GB`
  - :code:`-max_time = 48.h`
 
-The best practice to change the resources is to create a new config file and point to it at runtime by adding the flag :code:`-c path/to/config_file`
+The best practice to change the resources is to create a new config file and point to it at runtime by adding the 
+flag :code:`-c path/to/config_file`
 
 
-For example, to give all resource-intensive jobs more memory, create a file called :code:`overwrite_config.config` and insert
+For example, to give all resource-intensive jobs more memory, create a file called :code:`process_high_mem.config` and insert
 
 .. code-block:: bash
     
@@ -188,19 +238,20 @@ For example, to give all resource-intensive jobs more memory, create a file call
       }
     }
 
-Then your command to run the pipeline (assuming you've already run :code:`nf-core launch KwanLab/Autometa` which created a :code:`nf-params.json` file) would look something like:
+Then your command to run the pipeline (assuming you've already run :code:`nf-core launch KwanLab/Autometa` which created 
+a :code:`nf-params.json` file) would look something like:
 
 .. code-block:: bash
     
-    nextflow run KwanLab/Autometa -params-file nf-params.json -c overwrite_config.config
+    nextflow run KwanLab/Autometa -params-file nf-params.json -c process_high_mem.config
 
 
 
-For addtional information and examples see "Tuning workflow resources" `here <https://nf-co.re/usage/configuration#running-nextflow-on-your-system>`_
+For additional information and examples see `Tuning workflow resources <https://nf-co.re/usage/configuration#running-nextflow-on-your-system>`_
 
 
 
-Additional autometa parameters
+Additional Autometa parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Up to date descriptions and default values of Autometa's nextflow parameters can be viewed using the following command: 
@@ -212,44 +263,58 @@ Up to date descriptions and default values of Autometa's nextflow parameters can
 
 You can also adjust other pipeline parameters that ultimately control how the binning is performed.
 
-*params.length_cutoff* : Smallest contig you want binned (default is 3000bp)
+``params.length_cutoff`` : Smallest contig you want binned (default is 3000bp)
 
-*params.kmer_size* : kmer size to use
+``params.kmer_size`` : kmer size to use
 
-*params.norm_method* : Which normalization method to use. See :ref:`advanced-usage-kmers` section for deails
+``params.norm_method`` : Which kmer frequency normalization method to use. See 
+:ref:`advanced-usage-kmers` section for details
 
-*params.pca_dimensions* : Number of dimensions of which to reduce the initial k-mer frequencies matrix (default is 50). See :ref:`advanced-usage-kmers` section for deails
+``params.pca_dimensions`` : Number of dimensions of which to reduce the initial k-mer frequencies 
+matrix (default is ``50``). See :ref:`advanced-usage-kmers` section for details
 
-*params.embedding_method* :  Choices are "sksne", "bhsne", "umap" (default is bhsne) See :ref:`advanced-usage-kmers` section for deails
+``params.embedding_method`` :  Choices are ``sksne``, ``bhsne``, ``umap``, ``densmap``, ``trimap`` 
+(default is ``bhsne``) See :ref:`advanced-usage-kmers` section for details
 
-*params.embedding_dimensions* : Final dimensions of the kmer frequencies matrix (default is 2). See :ref:`advanced-usage-kmers` section for deails
+``params.embedding_dimensions`` : Final dimensions of the kmer frequencies matrix (default is ``2``). 
+See :ref:`advanced-usage-kmers` section for details
 
-*params.kingdom* : Bin contigs belonging to this kingdom. Choices are "bacteria" and "archaea" (default is bacteria). 
+``params.kingdom`` : Bin contigs belonging to this kingdom. Choices are ``bacteria`` and ``archaea`` 
+(default is ``bacteria``).
 
-*params.clustering_method* : Cluster contigs using which clustering method. Choices are "dbscan" and "hdbscan" (default is "dbscan"). See :ref:`advanced-usage-binning` section for deails
+``params.clustering_method`` : Cluster contigs using which clustering method. Choices are "dbscan" and "hdbscan" 
+(default is "dbscan"). See :ref:`advanced-usage-binning` section for details
 
-*params.binning_starting_rank* : Which taxonomic rank to start the binning from. Choices are "superkingdom", "phylum", "class", "order", "family", "genus", "species" (default is "superkingdom"). See :ref:`advanced-usage-binning` section for deails
+``params.binning_starting_rank`` : Which taxonomic rank to start the binning from. Choices are ``superkingdom``, ``phylum``, 
+``class``, ``order``, ``family``, ``genus``, ``species`` (default is ``superkingdom``). See :ref:`advanced-usage-binning` section for details
 
-*params.classification_method* : Which clustering method to use for unclustered recruitment step. Choices are "decision_tree" and "random_forest" (default is "decision_tree"). See :ref:`advanced-usage-unclustered-recruitment` section for deails
+``params.classification_method`` : Which clustering method to use for unclustered recruitment step. 
+Choices are ``decision_tree`` and ``random_forest`` (default is ``decision_tree``). See :ref:`advanced-usage-unclustered-recruitment` section for details
 
-*params.completeness* :  Minimum completeness needed to keep a cluster (default is atleast 20% complete). See :ref:`advanced-usage-binning` section for deails
+``params.completeness`` :  Minimum completeness needed to keep a cluster (default is at least 20% complete, e.g. ``20``). 
+See :ref:`advanced-usage-binning` section for details
 
-*params.purity* : Minimum purity needed to keep a cluster (default is atleast 95% pure). See :ref:`advanced-usage-binning` section for deails
+``params.purity`` : Minimum purity needed to keep a cluster (default is atleast 95% pure, e.g. ``95``). 
+See :ref:`advanced-usage-binning` section for details
 
-*params.cov_stddev_limit* : Which clusters to keep depending on the covergae std.dev (default is 25%). See :ref:`advanced-usage-binning` section for deails
+``params.cov_stddev_limit`` : Which clusters to keep depending on the covergae std.dev (default is 25%, e.g. ``25``). 
+See :ref:`advanced-usage-binning` section for details
 
-*params.gc_stddev_limit* : Which clusters to keep depending on the GC% std.dev (default is 5%). See :ref:`advanced-usage-binning` section for deails
+``params.gc_stddev_limit`` : Which clusters to keep depending on the GC% std.dev (default is 5%, e.g. ``5``). 
+See :ref:`advanced-usage-binning` section for details
 
 
 Customizing Autometa's Scripts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-In case you want to tweak some of the scripts, run on your own scheduling system or modify the pipeline you can clone the repository and then run nextflow directly from the scripts as below:
+In case you want to tweak some of the scripts, run on your own scheduling system or modify the pipeline you can clone 
+the repository and then run nextflow directly from the scripts as below:
+
 .. code-block:: bash
 
     # Clone the autometa repository into current directory
-    git clone git@github.com:KwanLab/Autometa.git 
+    git clone -b dev git@github.com:KwanLab/Autometa.git 
     # Modify some code
     # Then run nextflow
     nextflow run $HOME/Autometa/nextflow
@@ -262,33 +327,48 @@ Without docker
 Useful options
 ^^^^^^^^^^^^^^
 
-``-c`` : In case you have configured nextflow_ with your executor (see :ref:`Configure nextflow with your 'executor'`) and have made other modifications on how to run nextflow_ using your ``nexflow.config`` file, you can specify that file using the ``-c`` flag
+``-c`` : In case you have configured nextflow with your executor (see :ref:`Configure nextflow with your 'executor'`) 
+and have made other modifications on how to run nextflow using your ``nexflow.config`` file, you can specify that file 
+using the ``-c`` flag
 
-To see all of the command line options available you can refer to `nexflow CLI documentation <https://www.nextflow.io/docs/latest/cli.html#command-line-interface-cli>`_
+To see all of the command line options available you can refer to 
+`nexflow CLI documentation <https://www.nextflow.io/docs/latest/cli.html#command-line-interface-cli>`_
 
 Resuming the workflow
 ^^^^^^^^^^^^^^^^^^^^^
 
-One of the most powerful features of nextflow_ is resuming the workflow from the last completed process. If your pipeline was interrupted for some reason you can resume it from the last completed process using the resume flag (``-resume``). Eg, ``nextflow run KwanLab/Autometa -params-file nf-params.json -c my_other_parameters.config -resume``
+One of the most powerful features of nextflow is resuming the workflow from the last completed process. If your pipeline 
+was interrupted for some reason you can resume it from the last completed process using the resume flag (``-resume``). 
+Eg, ``nextflow run KwanLab/Autometa -params-file nf-params.json -c my_other_parameters.config -resume``
 
 Execution Report
 ^^^^^^^^^^^^^^^^
 
-After running nextflow you can see the execution statistics of your autometa run, including the time taken, CPUs used, RAM used, etc separately for each process. Nextflow would generate a summary report, a timeline report and a trace report automatically for you in the ``"${params.tracedir}/pipeline_info`` directory (``"${params.tracedir}`` defaults to ``autometa_tracedir``). You can read more about these execution reports `here <https://www.nextflow.io/docs/latest/tracing.html#execution-report>`_. 
+After running nextflow you can see the execution statistics of your autometa run, including the time taken, CPUs used, 
+RAM used, etc separately for each process. Nextflow would generate a summary report, a timeline report and a trace report 
+automatically for you in the ``"${params.tracedir}/pipeline_info`` directory (``"${params.tracedir}`` defaults to 
+``autometa_tracedir``). You can read more about this in the 
+`nextflow docs on execution reports <https://www.nextflow.io/docs/latest/tracing.html#execution-report>`_. 
 
 Workflow Visualized
 ^^^^^^^^^^^^^^^^^^^
 
-You can also visualize the entire workflow ie. create the DAG from the written DOT file. Install `Graphviz <https://graphviz.org/>`_ and do ``dot -Tpng < pipeline_info/autometa-dot > autometa-dag.png`` to get the in the ``png`` format.
+You can also visualize the entire workflow ie. create the DAG from the written DOT file. Install 
+`Graphviz <https://graphviz.org/>`_ (``conda install -c anaconda graphviz``) and do ``dot -Tpng < pipeline_info/autometa-dot > autometa-dag.png`` to get the 
+in the ``png`` format.
 
 Configure nextflow with your 'executor'
----------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. todo::
+For nextflow to run the Autometa pipeline through a job scheduler you will need to update the respective ``profile`` 
+section in nextflow's config file. Each ``profile`` may be configured with any available scheduler as noted in the 
+`nextflow executors docs <https://www.nextflow.io/docs/latest/executor.html>`_. By default nextflow will use your 
+local computer as the 'executor'. The next section briefly walks through nextflow executor configuration to run 
+with the slurm job scheduler.
 
-For nextflow_ to run the Autometa pipeline through a job scheduler you will need to update the respective 'profile' section in nextflow's config file. Each 'profile' may be configured with any available scheduler as noted in the `nextflow executors docs <https://www.nextflow.io/docs/latest/executor.html>`_. By default nextflow_ will use your local computer as the 'executor'. The next section briefly walks through nextflow_ executor configuration to run with the slurm job scheduler.
-
-We have prepared a template for ``nextflow.config`` which you can access from our GitHub repository using this `link <https://github.com/WiscEvan/Autometa/blob/4b4e3c60e076706e28deae4ae4d45f26b5df7dee/nextflow.config>`_. Go ahead and copy this file to your desired location and open it in your favorite text editor (eg. Vim, nano, VSCode, etc).
+We have prepared a template for ``nextflow.config`` which you can access from the KwanLab/Autometa GitHub repository using this 
+`nextflow.config template <https://raw.githubusercontent.com/KwanLab/Autometa/dev/nextflow.config>`_. Go ahead 
+and copy this file to your desired location and open it in your favorite text editor (eg. Vim, nano, VSCode, etc).
 
 
 .. _using-slurm:
@@ -296,15 +376,14 @@ We have prepared a template for ``nextflow.config`` which you can access from ou
 SLURM
 ^^^^^
 
-This allows you to run the pipeline using the SLURM resource manager. To do this you'll first needed to identify the slurm partition to use. You can find the available slurm partitions by running ``sinfo``. Example: On running ``sinfo`` on our cluster we get the following:
+This allows you to run the pipeline using the SLURM resource manager. To do this you'll first needed to identify the 
+slurm partition to use. You can find the available slurm partitions by running ``sinfo``. Example: On running ``sinfo`` 
+on our cluster we get the following:
 
 .. image:: ../img/slurm_partitions.png
     :alt: Screen shot of ``sinfo`` output showing ``queue`` listed under partition  
 
-The slurm partition available on our cluster is queue.  You'll need to update this in ``nextflow.config``. 
-
-.. todo::
-    Change the path to ``nextflow.config`` after the merge.
+The slurm partition available on our cluster is ``queue``.  You'll need to update this in ``nextflow.config``. 
 
 .. code-block:: groovy
 
@@ -318,26 +397,19 @@ The slurm partition available on our cluster is queue.  You'll need to update th
     // See https://www.nextflow.io/docs/latest/executor.html#slurm for more details.
     }
 
-More parameters that are available for the slurm executor are listed in the nextflow `executor docs for slurm <https://www.nextflow.io/docs/latest/executor.html#slurm>`_.
+More parameters that are available for the slurm executor are listed in the nextflow 
+`executor docs for slurm <https://www.nextflow.io/docs/latest/executor.html#slurm>`_.
 
 
+Using a different Autometa docker image
+=======================================
 
-
-Docker version
-==============
-
-Using a different Docker image version of Autometa.
 
 Especially when developing new features it may be necessary to run the pipeline with a custom docker image. 
-Create a new image by navigating to the top Autometa directory and running `make image`. This will create a new 
+Create a new image by navigating to the top Autometa directory and running ``make image``. This will create a new 
 Autometa Docker image, tagged with the name of the current Git branch. 
 
-To use this tagged version (or any other Autometa image tag) add the argument --autometa_image tag_name to the nextflow run command
-
-
-
-
-
+To use this tagged version (or any other Autometa image tag) add the argument ``--autometa_image tag_name`` to the nextflow run command
 
 .. todo:: Below python specific maybe there should be two "running..." files, one for nextflow and one for python?
 

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -47,7 +47,7 @@ Using `conda <https://conda.io/projects/conda/en/latest/user-guide/install/index
 
 .. code-block:: bash
 
-    conda create -c conda-forge -c bioconda --name autometa-nf python=3 nf-core nextflow -y
+    conda create -c conda-forge -c bioconda --name autometa-nf python>=3.7 nf-core>=2 nextflow>=21.04.0 -y
 
 
 Once it finishes installing be sure to active the environment:
@@ -56,12 +56,11 @@ Once it finishes installing be sure to active the environment:
 
     conda activate autometa-nf
 
-Lastly, download the pipeline from GitHub using nextflow
+Optional: If you want to use nextflow directly and not nf-core tools download the pipeline from GitHub using nextflow.
 
 .. code-block:: bash
 
-    nextflow pull https://github.com/KwanLab/Autometa -r main
-
+    nextflow pull KwanLab/Autometa -r main
 
 
 Launching Autometa
@@ -69,17 +68,13 @@ Launching Autometa
 
 Run the pipeline using the command below. 
 
-Note: Unless specified using the parameters (:code:`--interim_dir`, :code:`--outdir`, and :code:`--tracedir`), intermediate and temporary files will be created relative to the directory this is executed from. 
-
 .. code-block:: bash
 
     nf-core launch KwanLab/Autometa
 
-You will then be provided two "launch method" options: "Web based" or "Command line". While it is possible to use the command line version, it is preferred and easier to use the Web based GUI.
+You will then be asked to choose "Web based" or "Command line". While it is possible to use the command line version, it is preferred and easier to use the web-based GUI.
 Use the arrow keys to select one or the other and then press return/enter.
 
-
-Note: You can use `tmux <https://github.com/tmux/tmux/wiki>`_ or `screen <https://www.gnu.org/software/screen/>`_ in case you want to exit the window or disconnect from the server.
 
 Set autometa parameters with web based GUI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,11 +83,10 @@ The GUI will present all available parameters, though some extra parameters may 
 
 The only mandatory parameters are :code:`--input` which is the path to your input metagenome's nucleotide FASTA file, and :code:`-profile`.
 
-Currently the availble options for :code:`-profile` are 
+The most common options for :code:`-profile` are 
 
 * **standard**: runs all process jobs locally. If you use slurm, don't use this.
-* **basic_slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm:` before using
-* **docker**: is currently required
+* **slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm:` before using
 
 An example input for locally-executed jobs would be 
 
@@ -106,9 +100,7 @@ An example input for slurm-executed jobs would be
 Running the pipeline
 ^^^^^^^^^^^^^^^^^^^^
 
-After you are finished double-checking your parameter settings, click "Launch" at the top right of web based GUI page, or "Launch workflow" at the bottom of the page.
-
-
+After you are finished double-checking your parameter settings, click "Launch" at the top right of web based GUI page, or "Launch workflow" at the bottom of the page. After returning to the terminal you should be provided the option :code:`Do you want to run this command now?  [y/n]`  enter :code:`y` to begin the pipeline.
 
 
 Advanced Nextflow
@@ -118,18 +110,8 @@ Advanced Nextflow
 Multiple Inputs
 ^^^^^^^^^^^^^^^
 
-You can also input multiple asseblies at once with the help of wildcards. In the below example all the files with extension "fasta" would be taken as input by nextflow_.
-
-.. code-block:: bash
-
-    // Find this section of code in parameters.config
-    params.metagenome = "$HOME/tutorial/test_data/*.fna"
-    params.interim = "$HOME/tutorial/interim/" 
-    params.processed = "$HOME/tutorial/processed/"
-
-.. note::
-    1. Wildcard characters will only be interpreted when "double quotes" are used
-    2. If the interim and processed directories doens't exist, nextflow would generate them 
+You can also input multiple assemblies at once with the help of wildcards. In the below example all the files with extension ".fna" would be taken as input by nextflow_.
+:code:`--input /tutorial/test_data/*.fna`
 
 Database directory
 ^^^^^^^^^^^^^^^^^^
@@ -197,10 +179,6 @@ Up to date descriptions and default values of Autometa's nextflow parameters can
 .. code-block:: bash
 
     nextflow run KwanLab/Autometa -r main --help
-
-
-
-
 
 
 You can also adjust other pipeline parameters that ultimately control how the binning is performed.
@@ -312,26 +290,6 @@ The slurm partition available on our cluster is queue.  You'll need to update th
     }
 
 More parameters that are available for the slurm executor are listed in the nextflow `executor docs for slurm <https://www.nextflow.io/docs/latest/executor.html#slurm>`_.
-
-HTCondor
-^^^^^^^^
-
-This allows you to run the pipeline using the HTCondor resource manager. To do this you'll need to enable the HTCondor executor to condor value in the ``nextflow.config``.
-
-.. code-block:: groovy
-
-    // Find this section of code in nextflow.config
-    }
-    chtc {
-        process.executor = "condor"
-        // See https://www.nextflow.io/docs/latest/executor.html#htcondor for more configuration options.
-    }
-
-More parameters that are available for the htcondor executor are listed in the nextflow executor `docs for HTCondor <https://www.nextflow.io/docs/latest/executor.html#htcondor>`_.
-
-.. note::
-    1. The pipeline must be launched from a node where the ``condor_submit`` command is available, that is, in a common usage scenario, the cluster head node.
-    2. The HTCondor executor for Nextflow_ does not support at this time the HTCondor ability to transfer input/output data to the corresponding job computing node. Therefore the data needs to be made accessible to the computing nodes using a shared file system directory from where the Nextflow_ workflow has to be executed (or specified via the -w option).
 
 
 

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -298,7 +298,16 @@ More parameters that are available for the slurm executor are listed in the next
 
 
 
+Docker version
+==============
 
+Using a different Docker image version of Autometa.
+
+Especially when developing new features it may be necessary to run the pipeline with a custom docker image. 
+Create a new image by navigating to the top Autometa directory and running `make image`. This will create a new 
+Autometa Docker image, tagged with the name of the current Git branch. 
+
+To use this tagged version (or any other Autometa image tag) add the argument --autometa_image tag_name to the nextflow run command
 
 
 

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -2,6 +2,8 @@
 Running Autometa
 ================
 
+.. For description of appropriate header levels see:
+    https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/HeadlinesAndSection.html#headlines-and-sections
 
 Why nextflow?
 =============
@@ -63,7 +65,7 @@ Conda environment to install Nextflow and nf-core tools and then running the Aut
 .. _install-nextflow-nfcore-with-conda:
 
 Installing Nextflow and nf-core tools with Conda
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------------------
 
 If you have not previously installed/used Conda, you can get it using the 
 Miniconda installer appropriate to your system, here: `<https://docs.conda.io/en/latest/miniconda.html>`_
@@ -94,7 +96,7 @@ Once Conda has finished creating the environment be sure to activate it:
 
     
 Launching Autometa using nf-core tools
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------
 
 Download/Launch the Autometa Nextflow pipeline using nf-core tools. 
 The stable version of Autometa will always be the "main" git branch. 
@@ -112,20 +114,22 @@ Use the arrow keys to select one or the other and then press return/enter.
 
 
 Set autometa parameters with nf-core tools web based GUI
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------------------------
 
 The GUI will present all available parameters, though some extra 
 parameters may be hidden (these can be revealed by selecting 
 "Show hidden params" on the right side of the page).
 
-* Parameters to set every time
-    - ``--input``: the path to your input metagenome's nucleotide FASTA file
-    - ``-profile``: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
-        - **standard** (default): runs all process jobs locally, (currently this requires Docker).
-        - **slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm` before using
+Parameters to set every time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``--input``: the path to your input metagenome assembly nucleotide FASTA file
+- ``-profile``: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
+    - **standard** (default): runs all process jobs locally, (currently this requires Docker).
+    - **slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm` before using
 
 Running the pipeline
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 After you are finished double-checking your parameter settings, click "Launch" 
 at the top right of web based GUI page, or "Launch workflow" at the bottom of 
 the page. After returning to the terminal you should be provided the option 
@@ -147,7 +151,7 @@ Advanced
 ========
 
 Parallel computing and computer resource allotment
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------------------
 
 While you might want to provide Autometa all the compute resources available in order to get results 
 faster, that may or may not actually achieve the fastest run time.
@@ -171,14 +175,14 @@ largest gain in performance and a good rule would be to not exceed the number of
 
 
 Multiple Inputs
-^^^^^^^^^^^^^^^
+---------------
 
 You can input multiple assemblies at once using path wildcards. In the below example all the files with extension ".fna" 
 would be taken as input by nextflow. The pipeline will organize/name outputs based on these filenames.
 :code:`--input /tutorial/test_data/*.fna`
 
 Databases
-^^^^^^^^^
+---------
 
 Autometa uses the following NCBI databases throughout its pipeline:
 
@@ -209,7 +213,7 @@ Make sure that the directory path contains the following databases:
     params.single_db_dir = "/Autometa/autometa/databases/ncbi"
 
 CPUs, Memory, Disk
-^^^^^^^^^^^^^^^^^^
+------------------
 
 .. note::
     
@@ -246,10 +250,8 @@ a :code:`nf-params.json` file) would look something like:
 
 For additional information and examples see `Tuning workflow resources <https://nf-co.re/usage/configuration#running-nextflow-on-your-system>`_
 
-
-
 Additional Autometa parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------
 
 Up to date descriptions and default values of Autometa's nextflow parameters can be viewed using the following command: 
 
@@ -302,8 +304,7 @@ See :ref:`advanced-usage-binning` section for details
 
 
 Customizing Autometa's Scripts
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+------------------------------
 
 In case you want to tweak some of the scripts, run on your own scheduling system or modify the pipeline you can clone 
 the repository and then run nextflow directly from the scripts as below:
@@ -317,7 +318,7 @@ the repository and then run nextflow directly from the scripts as below:
     nextflow run $HOME/Autometa/nextflow
 
 Useful options
-^^^^^^^^^^^^^^
+--------------
 
 ``-c`` : In case you have configured nextflow with your executor (see :ref:`Configure nextflow with your 'executor'`) 
 and have made other modifications on how to run nextflow using your ``nexflow.config`` file, you can specify that file 
@@ -327,14 +328,14 @@ To see all of the command line options available you can refer to
 `nexflow CLI documentation <https://www.nextflow.io/docs/latest/cli.html#command-line-interface-cli>`_
 
 Resuming the workflow
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 One of the most powerful features of nextflow is resuming the workflow from the last completed process. If your pipeline 
 was interrupted for some reason you can resume it from the last completed process using the resume flag (``-resume``). 
 Eg, ``nextflow run KwanLab/Autometa -params-file nf-params.json -c my_other_parameters.config -resume``
 
 Execution Report
-^^^^^^^^^^^^^^^^
+----------------
 
 After running nextflow you can see the execution statistics of your autometa run, including the time taken, CPUs used, 
 RAM used, etc separately for each process. Nextflow would generate a summary report, a timeline report and a trace report 
@@ -343,14 +344,14 @@ automatically for you in the ``${params.tracedir}/pipeline_info`` directory (``$
 `nextflow docs on execution reports <https://www.nextflow.io/docs/latest/tracing.html#execution-report>`_. 
 
 Visualizing the Workflow 
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 
 You can visualize the entire workflow ie. create the directed acyclic graph (DAG) of processes from the written DOT file. First install 
 `Graphviz <https://graphviz.org/>`_ (``conda install -c anaconda graphviz``) then do ``dot -Tpng < pipeline_info/autometa-dot > autometa-dag.png`` to get the 
 in the ``png`` format.
 
 Configure nextflow with your 'executor'
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 For nextflow to run the Autometa pipeline through a job scheduler you will need to update the respective ``profile`` 
 section in nextflow's config file. Each ``profile`` may be configured with any available scheduler as noted in the 
@@ -366,7 +367,7 @@ and copy this file to your desired location and open it in your favorite text ed
 .. _using-slurm:
 
 SLURM
-^^^^^
+-----
 
 This allows you to run the pipeline using the SLURM resource manager. To do this you'll first needed to identify the 
 slurm partition to use. You can find the available slurm partitions by running ``sinfo``. Example: On running ``sinfo`` 

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -12,6 +12,8 @@ Before you run Autometa, you need to have assembled your shotgun metagenome. The
 #. Assemble the trimmed reads. We recommend using MetaSPAdes which is a part of the SPAdes_ package to assemble the trimmed reads but you can use any other assembler as well.
 #. An optional thing to do here would be to check the quality of your assembly as well. This would give you a variety of assembly statistics one of which is N50 which will be useful in selecting the cutoff value during the Autometa length-filter step. We tend to use metaQuast_ for this (use ``--min-contig 1`` option to get an accurate N50).
 
+.. TODO: SPAdes info is for python version, currently the Nextflow version assumes everything is from SPAdes. It's not clear how coverage is used.
+
 .. note::
 
     If you use SPAdes then Autometa can use the k-mer coverage information in the contig names. If you have used any other assembler, then you first have to make a coverage table.
@@ -32,14 +34,13 @@ System Requirements
 
 Nextflow 
 
-Currently the nextflow pipeline only works with Docker so Docker must be installed on your system `Get Docker <https://docs.docker.com/get-docker>`_. We do plan on removing this Docker dependency.
+Currently the nextflow pipeline only works with Docker so Docker must be installed on your system `Get Docker <https://docs.docker.com/get-docker>`_. We do plan on removing this dependency on Docker.
 
 Nextflow runs on any Linux compatible system or MacOS with Java installed. 
 
 
 Quick Start
 ------------
-
 
 Installation
 ^^^^^^^^^^^^
@@ -56,15 +57,18 @@ Once it finishes installing be sure to active the environment:
 
     conda activate autometa-nf
 
-Optional: If you want to use nextflow directly and not nf-core tools download the pipeline from GitHub using nextflow.
+After launching for the first time (next section), the pipeline will download and install dependencies as required (either with Docker or Conda, as selected). 
+
+Optional: If you want to use nextflow directly and not through nf-core tools, download the pipeline from GitHub using nextflow.
 
 .. code-block:: bash
 
     nextflow pull KwanLab/Autometa -r main
 
+    
 
-Launching Autometa
-^^^^^^^^^^^^^^^^^^
+Launching Autometa with nf-core tools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Run the pipeline using the command below. 
 
@@ -72,7 +76,7 @@ Run the pipeline using the command below.
 
     nf-core launch KwanLab/Autometa
 
-You will then be asked to choose "Web based" or "Command line". While it is possible to use the command line version, it is preferred and easier to use the web-based GUI.
+You will then be asked to choose "Web based" or "Command line" in order to select/provide options. While it is possible to use the command line version, it is preferred and easier to use the web-based GUI.
 Use the arrow keys to select one or the other and then press return/enter.
 
 

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -123,10 +123,16 @@ parameters may be hidden (these can be revealed by selecting
 Parameters to set every time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``--input``: the path to your input metagenome assembly nucleotide FASTA file
-- ``-profile``: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
-    - **standard** (default): runs all process jobs locally, (currently this requires Docker).
-    - **slurm**: submits all process jobs into the slurm queue. See :ref:`using-slurm` before using
+``--input``: the path to your input metagenome assembly nucleotide FASTA file
+
+``-profile``: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
+    - ``standard`` (default): runs all process jobs locally, (currently this requires Docker).
+    - ``slurm``: submits all process jobs into the slurm queue. See :ref:`using-slurm` before using
+
+.. note::
+    Notice the number of hyphens used between ``--input`` and ``-profile``. ``--input`` is an Autometa workflow parameter
+    where as ``-profile`` is a nextflow argument. This difference is true for passing in all arguments to the Autometa 
+    workflow and nextflow, respectively.
 
 Running the pipeline
 --------------------


### PR DESCRIPTION
Adds the basic steps on how to run Autometa using nextflow. Still a work in progress on more advanced configs.

Basic steps won't work unless https://github.com/KwanLab/Autometa/pull/181 is merged (or when dev is eventually merged)