### PR TITLE
Fix bedtools genomecov deprecation (coverage calculation)

### DIFF
--- a/modules/local/parse_bed.nf
+++ b/modules/local/parse_bed.nf
@@ -28,7 +28,7 @@ process PARSE_BED {
     script:
         def software = getSoftwareName(task.process)
         """
-        autometa-parse-bed \\
+        autometa-bedtools-genomecov \\
             --ibam $bam \\
             --lengths $lengths \\
             --bed $bed_out \\

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
             "autometa-length-filter = autometa.common.metagenome:main",
             "autometa-markers = autometa.common.markers:main",
             "autometa-orfs = autometa.common.external.prodigal:main",
-            "autometa-parse-bed = autometa.common.external.bedtools:main",
+            "autometa-bedtools-genomecov = autometa.common.external.bedtools:main",
             "autometa-hmmsearch-filter = autometa.common.external.hmmsearch:main",
             "autometa-taxonomy = autometa.taxonomy.vote:main",
             "autometa-taxonomy-lca = autometa.taxonomy.lca:main",

--- a/tests/unit_tests/test_coverage.py
+++ b/tests/unit_tests/test_coverage.py
@@ -189,7 +189,6 @@ def test_coverage_main(
             self.rev_reads = rev_reads
             self.sam = sam_alignment
             self.bam = bam_alignment
-            self.lengths = "lengths.tsv"
             self.bed = bed_alignment
             self.cpus = 2
             self.out = out


### PR DESCRIPTION
- 🐍 :fire: Remove deprecated argument bedtools genomecov command
- :snake::green_apple: Rename entrypoint for clarity: `autometa-parse-bed` -> `autometa-bedtools-genomecov`
- 🍏 🎨 Update `parse_bed.nf` with updated autometa entrypoint
- :snake::fire::white_check_mark: Remove unneeded param in `test_coverage.py`
- :snake::fire: remove unneeded `make_length_table(...)` from `coverage.py`