### PR TITLE
🍏 Change Nextflow I/O behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,4 @@ pipeline_info
 work/
 large_db/
 nf-params.json
-autometa_interim_dir/
-autometa_outdir/
-autometa_tracedir/
-
+autometa-nxf-output

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -51,7 +51,7 @@ The following workflow is recommended:
 
     If you use SPAdes then Autometa can use the k-mer coverage information in the contig names. If you have used any other assembler, then you first have to make a coverage table.
 
-    Fortunately, Autometa can construct this table for you with: ``autometa-coverage``. Use ``--help`` to get the complete usage. :ref:`coverage`
+    Fortunately, Autometa can construct this table for you with: ``autometa-coverage``. Use ``--help`` to get the complete usage or for a few examples see :ref:`coverage-calculation`
 
 
 Basic

--- a/docs/source/running-autometa.rst
+++ b/docs/source/running-autometa.rst
@@ -13,12 +13,12 @@ Nextflow helps Autometa produce reproducible results while allowing the pipeline
 System Requirements
 ===================
 
-Currently the nextflow pipeline requires Docker so it must be installed on your system. 
+Currently the nextflow pipeline requires Docker so it must be installed on your system.
 If you don't have Docker installed you can install it from `docs.docker.com/get-docker <https://docs.docker.com/get-docker>`_.
-We plan on removing this dependency in future versions, so that other dependency managers 
+We plan on removing this dependency in future versions, so that other dependency managers
 (e.g. Conda, Singularity, etc) can be used.
 
-Nextflow runs on any Posix compatible system. Detailed system requirements 
+Nextflow runs on any Posix compatible system. Detailed system requirements
 can be found in the `nextflow documentation <https://www.nextflow.io/docs/latest/getstarted.html#requirements>`_
 
 Nextflow (required) and nf-core tools (optional but highly recommended) installation will be discussed in :ref:`install-nextflow-nfcore-with-conda`.
@@ -27,10 +27,10 @@ Nextflow (required) and nf-core tools (optional but highly recommended) installa
 Data preparation
 ================
 
-Autometa takes contigs as input, so you need to have previously assembled your shotgun metagenome. 
+Autometa takes contigs as input, so you need to have previously assembled your shotgun metagenome.
 The following workflow is recommended:
 
-#. Trim adapter sequences from the reads. 
+#. Trim adapter sequences from the reads.
 
    * We usually use Trimmomatic_.
 
@@ -38,40 +38,40 @@ The following workflow is recommended:
 
    * We usually use FastQC_.
 
-#. Assemble the trimmed reads. 
+#. Assemble the trimmed reads.
 
    * We usually use MetaSPAdes which is a part of the SPAdes_ package.
 
-#. An optional thing to do here would be to check the quality of your assembly as well. This would give you a variety of assembly statistics one of which is N50 which will be useful in selecting the cutoff value during the Autometa length-filter step. 
-   
+#. An optional thing to do here would be to check the quality of your assembly as well. This would give you a variety of assembly statistics one of which is N50 which will be useful in selecting the cutoff value during the Autometa length-filter step.
+
    * We usually use metaQuast_ for this (use ``--min-contig 1`` option to get an accurate N50).
 
 
-.. note::
+.. attention::
 
     If you use SPAdes then Autometa can use the k-mer coverage information in the contig names. If you have used any other assembler, then you first have to make a coverage table.
 
-    Fortunately, Autometa can construct this table for you with: ``autometa-coverage``. Use ``--help`` to get the complete usage.
+    Fortunately, Autometa can construct this table for you with: ``autometa-coverage``. Use ``--help`` to get the complete usage. :ref:`coverage`
 
 
 Basic
 =====
 
-While the Autometa Nextflow pipeline can be run using Nextflow directly, we designed 
-it using nf-core standards and templating to provide an easier user experience through 
-use of the nf-core "tools" python library. The directions below demonstrate using a minimal 
-Conda environment to install Nextflow and nf-core tools and then running the Autometa pipeline. 
+While the Autometa Nextflow pipeline can be run using Nextflow directly, we designed
+it using nf-core standards and templating to provide an easier user experience through
+use of the nf-core "tools" python library. The directions below demonstrate using a minimal
+Conda environment to install Nextflow and nf-core tools and then running the Autometa pipeline.
 
 .. _install-nextflow-nfcore-with-conda:
 
 Installing Nextflow and nf-core tools with Conda
 ------------------------------------------------
 
-If you have not previously installed/used Conda, you can get it using the 
+If you have not previously installed/used Conda, you can get it using the
 Miniconda installer appropriate to your system, here: `<https://docs.conda.io/en/latest/miniconda.html>`_
 
 After installing conda, running the following command will create a minimal
- Conda environment named "autometa-nf", and install Nextflow and nf-core tools.
+Conda environment named "autometa-nf", and install Nextflow and nf-core tools.
 
 .. code-block:: bash
 
@@ -83,10 +83,12 @@ If you receive the message...
 
     CondaValueError: prefix already exists:
 
-...it means you have already created the environment. If you want to overwrite/update 
-the environment then add the force flag to the end of the 
-command: :code:`conda env create... --force`
+...it means you have already created the environment. If you want to overwrite/update
+the environment then add the :code:`--force` flag to the end of the command.
 
+.. code-block:: bash
+
+    conda env create --file=https://raw.githubusercontent.com/KwanLab/Autometa/dev/environment.yml --force
 
 Once Conda has finished creating the environment be sure to activate it:
 
@@ -94,14 +96,14 @@ Once Conda has finished creating the environment be sure to activate it:
 
     conda activate autometa-nf
 
-    
+
 Launching Autometa using nf-core tools
 --------------------------------------
 
-Download/Launch the Autometa Nextflow pipeline using nf-core tools. 
-The stable version of Autometa will always be the "main" git branch. 
-To use an in-development git branch switch "main" in the command with 
-the name of the desired branch. After the pipeline downloads nf-core will 
+Download/Launch the Autometa Nextflow pipeline using nf-core tools.
+The stable version of Autometa will always be the "main" git branch.
+To use an in-development git branch switch "main" in the command with
+the name of the desired branch. After the pipeline downloads nf-core will
 start the pipeline launch process.
 
 .. code-block:: bash
@@ -113,37 +115,38 @@ While it is possible to use the command line version, it is preferred and easier
 Use the arrow keys to select one or the other and then press return/enter.
 
 
-Set autometa parameters with nf-core tools web based GUI
+Set Autometa parameters with nf-core tools web based GUI
 --------------------------------------------------------
 
-The GUI will present all available parameters, though some extra 
-parameters may be hidden (these can be revealed by selecting 
+The GUI will present all available parameters, though some extra
+parameters may be hidden (these can be revealed by selecting
 "Show hidden params" on the right side of the page).
 
 Parameters to set every time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``--input``: the path to your input metagenome assembly nucleotide FASTA file
+:code:`--input`: the path to your input metagenome assembly nucleotide FASTA file
 
-``-profile``: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
-    - ``standard`` (default): runs all process jobs locally, (currently this requires Docker).
-    - ``slurm``: submits all process jobs into the slurm queue. See :ref:`using-slurm` before using
+:code:`-profile`: this sets options specified within the "profiles" section in the pipeline's nextflow.config file
+    - :code:`standard` (default): runs all process jobs locally, (currently this requires Docker).
+    - :code:`slurm`: submits all process jobs into the slurm queue. See :ref:`using-slurm` before using
 
-.. note::
-    Notice the number of hyphens used between ``--input`` and ``-profile``. ``--input`` is an Autometa workflow parameter
-    where as ``-profile`` is a nextflow argument. This difference is true for passing in all arguments to the Autometa 
-    workflow and nextflow, respectively.
+.. caution::
+
+    Notice the number of hyphens used between ``--input`` and ``-profile``. ``--input`` is an `Autometa` workflow parameter
+    where as ``-profile`` is a `nextflow` argument. This difference is true for passing in all arguments to the `Autometa`
+    workflow and `nextflow`, respectively.
 
 Running the pipeline
 --------------------
-After you are finished double-checking your parameter settings, click "Launch" 
-at the top right of web based GUI page, or "Launch workflow" at the bottom of 
-the page. After returning to the terminal you should be provided the option 
+After you are finished double-checking your parameter settings, click "Launch"
+at the top right of web based GUI page, or "Launch workflow" at the bottom of
+the page. After returning to the terminal you should be provided the option
 :code:`Do you want to run this command now?  [y/n]`  enter :code:`y` to begin the pipeline.
 
 .. note::
 
-    This process will lead to nf-core tools creating a file named :code:`nf-params.json`. 
+    This process will lead to nf-core tools creating a file named :code:`nf-params.json`.
     This file contains your specified parameters that differed from the pipeline's defaults.
     This file can also be manually modified and/or shared to allow reproducible configuration
     of settings (e.g. among members within a lab sharing the same server).
@@ -159,31 +162,31 @@ Advanced
 Parallel computing and computer resource allotment
 --------------------------------------------------
 
-While you might want to provide Autometa all the compute resources available in order to get results 
+While you might want to provide Autometa all the compute resources available in order to get results
 faster, that may or may not actually achieve the fastest run time.
 
-Within the Autometa pipeline, parallelization happens two ways: 1) by providing all the contigs at once 
-to software that handles parallelization internally; 2) by splitting the input FASTA into batches of contigs 
+Within the Autometa pipeline, parallelization happens two ways: 1) by providing all the contigs at once
+to software that handles parallelization internally; 2) by splitting the input FASTA into batches of contigs
 which are provided in parallel to non-parallelized software.
 
-In regards to the first method: The Autometa pipeline will try and use all resources available to individual 
-pipeline modules. Each module/process has been pre-assigned resource allotments via a low/medium/high tag. 
-This means that even if you don't select for the pipeline to run in parallel some modules (e.g. DIAMOND BLAST) 
-may still use multiple cores. The maximum number of CPUs that any single module can use is defined with 
-the :code:`--max_cpus` option (default: 4). You can also set :code:`--max_memory` (default: 16GB) and/or 
-:code:`--max_time` (default: 240h). :code:`--max_time` refers to the maximum time *each process* is allowed to run, 
+In regards to the first method: The Autometa pipeline will try and use all resources available to individual
+pipeline modules. Each module/process has been pre-assigned resource allotments via a low/medium/high tag.
+This means that even if you don't select for the pipeline to run in parallel some modules (e.g. DIAMOND BLAST)
+may still use multiple cores. The maximum number of CPUs that any single module can use is defined with
+the :code:`--max_cpus` option (default: 4). You can also set :code:`--max_memory` (default: 16GB) and/or
+:code:`--max_time` (default: 240h). :code:`--max_time` refers to the maximum time *each process* is allowed to run,
 *not* the execution time for the the entire pipeline.
 
-In regards to the 2nd method: The Autometa pipeline will split the input metagenome FASTA file into the specified 
-number of files which can be set by providing an integer value to the option: :code:`--num_splits` (default: 
-:code:`1`- no splits, not run in parallel). Choosing the largest number of parallel processes possible may not provide 
-largest gain in performance and a good rule would be to not exceed the number of avaliable cores available.
+In regards to the 2nd method: The Autometa pipeline will split the input metagenome FASTA file into the specified
+number of files which can be set by providing an integer value to the option: :code:`--num_splits` (default:
+:code:`1`- no splits, not run in parallel). Choosing the largest number of parallel processes possible may not provide
+largest gain in performance and a good rule would be to not exceed the number of available cores available.
 
 
 Multiple Inputs
 ---------------
 
-You can input multiple assemblies at once using path wildcards. In the below example all the files with extension ".fna" 
+You can input multiple assemblies at once using path wildcards. In the below example all the files with extension ".fna"
 would be taken as input by nextflow. The pipeline will organize/name outputs based on these filenames.
 :code:`--input /tutorial/test_data/*.fna`
 
@@ -197,15 +200,15 @@ Autometa uses the following NCBI databases throughout its pipeline:
 - prot.accession2taxid.gz
     - `ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz <https://ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz>`_
 - nodes.dmp, names.dmp and merged.dmp - Found within
-    - `ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz <ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz>`_ 
+    - `ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz <ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz>`_
 
-If you are running autometa for the first time you'll have to download these databases. 
-You may use ``autometa-update-databases --update-ncbi``. This will download the databases to the default path. You can check 
-the default paths using ``autometa-config --print``. If you need to change the default download directory you can use 
-``autometa-config --section databases --option ncbi --value <path/to/new/ncbi_database_directory>``. 
+If you are running autometa for the first time you'll have to download these databases.
+You may use ``autometa-update-databases --update-ncbi``. This will download the databases to the default path. You can check
+the default paths using ``autometa-config --print``. If you need to change the default download directory you can use
+``autometa-config --section databases --option ncbi --value <path/to/new/ncbi_database_directory>``.
 See ``autometa-update-databases -h`` and ``autometa-config -h`` for full list of options.
 
-In your ``parameters.config`` file you also need to specify the directory where the different databases are present. 
+In your ``parameters.config`` file you also need to specify the directory where the different databases are present.
 Make sure that the directory path contains the following databases:
 
 - Diamond formatted nr file => nr.dmnd
@@ -222,35 +225,40 @@ CPUs, Memory, Disk
 ------------------
 
 .. note::
-    
-    Like nf-core pipelines, we have set some automatic defaults for Autometa's processes. These are dynamic and each 
-    process will try a second attempt using more resources if the first fails due to resources. Resources are always 
+
+    Like nf-core pipelines, we have set some automatic defaults for Autometa's processes. These are dynamic and each
+    process will try a second attempt using more resources if the first fails due to resources. Resources are always
     capped by the parameters (show with defaults):
 
- - :code:`-max_cpus = 2` 
- - :code:`-max_memory = 6.GB`
- - :code:`-max_time = 48.h`
+    - :code:`--max_cpus = 2`
+    - :code:`--max_memory = 6.GB`
+    - :code:`--max_time = 48.h`
 
-The best practice to change the resources is to create a new config file and point to it at runtime by adding the 
+The best practice to change the resources is to create a new config file and point to it at runtime by adding the
 flag :code:`-c path/to/config_file`
 
 
-For example, to give all resource-intensive jobs more memory, create a file called :code:`process_high_mem.config` and insert
+For example, to give all resource-intensive (i.e. having ``label process_high``) jobs additional memory and cpus, create a file called :code:`process_high_mem.config` and insert
 
-.. code-block:: bash
-    
-    process {
-      withLabel:process_high {
+.. code-block:: groovy
+
+process {
+    withLabel:process_high {
         memory = 200.GB
-      }
+        cpus = 32
     }
+}
 
-Then your command to run the pipeline (assuming you've already run :code:`nf-core launch KwanLab/Autometa` which created 
+Then your command to run the pipeline (assuming you've already run :code:`nf-core launch KwanLab/Autometa` which created
 a :code:`nf-params.json` file) would look something like:
 
 .. code-block:: bash
-    
+
     nextflow run KwanLab/Autometa -params-file nf-params.json -c process_high_mem.config
+
+.. attention::
+
+    If you are restarting from a previous run, do not forget to also add the ``-resume`` flag to the nextflow run command
 
 
 
@@ -259,7 +267,7 @@ For additional information and examples see `Tuning workflow resources <https://
 Additional Autometa parameters
 ------------------------------
 
-Up to date descriptions and default values of Autometa's nextflow parameters can be viewed using the following command: 
+Up to date descriptions and default values of Autometa's nextflow parameters can be viewed using the following command:
 
 .. code-block:: bash
 
@@ -272,53 +280,53 @@ You can also adjust other pipeline parameters that ultimately control how the bi
 
 ``params.kmer_size`` : kmer size to use
 
-``params.norm_method`` : Which kmer frequency normalization method to use. See 
+``params.norm_method`` : Which kmer frequency normalization method to use. See
 :ref:`advanced-usage-kmers` section for details
 
-``params.pca_dimensions`` : Number of dimensions of which to reduce the initial k-mer frequencies 
+``params.pca_dimensions`` : Number of dimensions of which to reduce the initial k-mer frequencies
 matrix (default is ``50``). See :ref:`advanced-usage-kmers` section for details
 
-``params.embedding_method`` :  Choices are ``sksne``, ``bhsne``, ``umap``, ``densmap``, ``trimap`` 
+``params.embedding_method`` :  Choices are ``sksne``, ``bhsne``, ``umap``, ``densmap``, ``trimap``
 (default is ``bhsne``) See :ref:`advanced-usage-kmers` section for details
 
-``params.embedding_dimensions`` : Final dimensions of the kmer frequencies matrix (default is ``2``). 
+``params.embedding_dimensions`` : Final dimensions of the kmer frequencies matrix (default is ``2``).
 See :ref:`advanced-usage-kmers` section for details
 
-``params.kingdom`` : Bin contigs belonging to this kingdom. Choices are ``bacteria`` and ``archaea`` 
+``params.kingdom`` : Bin contigs belonging to this kingdom. Choices are ``bacteria`` and ``archaea``
 (default is ``bacteria``).
 
-``params.clustering_method`` : Cluster contigs using which clustering method. Choices are "dbscan" and "hdbscan" 
+``params.clustering_method`` : Cluster contigs using which clustering method. Choices are "dbscan" and "hdbscan"
 (default is "dbscan"). See :ref:`advanced-usage-binning` section for details
 
-``params.binning_starting_rank`` : Which taxonomic rank to start the binning from. Choices are ``superkingdom``, ``phylum``, 
+``params.binning_starting_rank`` : Which taxonomic rank to start the binning from. Choices are ``superkingdom``, ``phylum``,
 ``class``, ``order``, ``family``, ``genus``, ``species`` (default is ``superkingdom``). See :ref:`advanced-usage-binning` section for details
 
-``params.classification_method`` : Which clustering method to use for unclustered recruitment step. 
+``params.classification_method`` : Which clustering method to use for unclustered recruitment step.
 Choices are ``decision_tree`` and ``random_forest`` (default is ``decision_tree``). See :ref:`advanced-usage-unclustered-recruitment` section for details
 
-``params.completeness`` :  Minimum completeness needed to keep a cluster (default is at least 20% complete, e.g. ``20``). 
+``params.completeness`` :  Minimum completeness needed to keep a cluster (default is at least 20% complete, e.g. ``20``).
 See :ref:`advanced-usage-binning` section for details
 
-``params.purity`` : Minimum purity needed to keep a cluster (default is atleast 95% pure, e.g. ``95``). 
+``params.purity`` : Minimum purity needed to keep a cluster (default is atleast 95% pure, e.g. ``95``).
 See :ref:`advanced-usage-binning` section for details
 
-``params.cov_stddev_limit`` : Which clusters to keep depending on the covergae std.dev (default is 25%, e.g. ``25``). 
+``params.cov_stddev_limit`` : Which clusters to keep depending on the covergae std.dev (default is 25%, e.g. ``25``).
 See :ref:`advanced-usage-binning` section for details
 
-``params.gc_stddev_limit`` : Which clusters to keep depending on the GC% std.dev (default is 5%, e.g. ``5``). 
+``params.gc_stddev_limit`` : Which clusters to keep depending on the GC% std.dev (default is 5%, e.g. ``5``).
 See :ref:`advanced-usage-binning` section for details
 
 
 Customizing Autometa's Scripts
 ------------------------------
 
-In case you want to tweak some of the scripts, run on your own scheduling system or modify the pipeline you can clone 
+In case you want to tweak some of the scripts, run on your own scheduling system or modify the pipeline you can clone
 the repository and then run nextflow directly from the scripts as below:
 
 .. code-block:: bash
 
     # Clone the autometa repository into current directory
-    git clone -b dev git@github.com:KwanLab/Autometa.git 
+    git clone -b dev git@github.com:KwanLab/Autometa.git
     # Modify some code
     # Then run nextflow
     nextflow run $HOME/Autometa/nextflow
@@ -326,47 +334,46 @@ the repository and then run nextflow directly from the scripts as below:
 Useful options
 --------------
 
-``-c`` : In case you have configured nextflow with your executor (see :ref:`Configure nextflow with your 'executor'`) 
-and have made other modifications on how to run nextflow using your ``nexflow.config`` file, you can specify that file 
+``-c`` : In case you have configured nextflow with your executor (see :ref:`Configure nextflow with your 'executor'`)
+and have made other modifications on how to run nextflow using your ``nexflow.config`` file, you can specify that file
 using the ``-c`` flag
 
-To see all of the command line options available you can refer to 
+To see all of the command line options available you can refer to
 `nexflow CLI documentation <https://www.nextflow.io/docs/latest/cli.html#command-line-interface-cli>`_
 
 Resuming the workflow
 ---------------------
 
-One of the most powerful features of nextflow is resuming the workflow from the last completed process. If your pipeline 
-was interrupted for some reason you can resume it from the last completed process using the resume flag (``-resume``). 
+One of the most powerful features of nextflow is resuming the workflow from the last completed process. If your pipeline
+was interrupted for some reason you can resume it from the last completed process using the resume flag (``-resume``).
 Eg, ``nextflow run KwanLab/Autometa -params-file nf-params.json -c my_other_parameters.config -resume``
 
 Execution Report
 ----------------
 
-After running nextflow you can see the execution statistics of your autometa run, including the time taken, CPUs used, 
-RAM used, etc separately for each process. Nextflow would generate a summary report, a timeline report and a trace report 
-automatically for you in the ``${params.tracedir}/pipeline_info`` directory (``${params.tracedir}`` defaults to 
-``autometa_tracedir``). You can read more about this in the 
-`nextflow docs on execution reports <https://www.nextflow.io/docs/latest/tracing.html#execution-report>`_. 
+After running nextflow you can see the execution statistics of your autometa run, including the time taken, CPUs used,
+RAM used, etc separately for each process. Nextflow will generate summary, timeline and trace reports automatically for
+you in the ``${params.outdir}/trace`` directory. You can read more about this in the
+`nextflow docs on execution reports <https://www.nextflow.io/docs/latest/tracing.html#execution-report>`_.
 
-Visualizing the Workflow 
+Visualizing the Workflow
 ------------------------
 
-You can visualize the entire workflow ie. create the directed acyclic graph (DAG) of processes from the written DOT file. First install 
-`Graphviz <https://graphviz.org/>`_ (``conda install -c anaconda graphviz``) then do ``dot -Tpng < pipeline_info/autometa-dot > autometa-dag.png`` to get the 
+You can visualize the entire workflow ie. create the directed acyclic graph (DAG) of processes from the written DOT file. First install
+`Graphviz <https://graphviz.org/>`_ (``conda install -c anaconda graphviz``) then do ``dot -Tpng < pipeline_info/autometa-dot > autometa-dag.png`` to get the
 in the ``png`` format.
 
 Configure nextflow with your 'executor'
 ---------------------------------------
 
-For nextflow to run the Autometa pipeline through a job scheduler you will need to update the respective ``profile`` 
-section in nextflow's config file. Each ``profile`` may be configured with any available scheduler as noted in the 
-`nextflow executors docs <https://www.nextflow.io/docs/latest/executor.html>`_. By default nextflow will use your 
-local computer as the 'executor'. The next section briefly walks through nextflow executor configuration to run 
+For nextflow to run the Autometa pipeline through a job scheduler you will need to update the respective ``profile``
+section in nextflow's config file. Each ``profile`` may be configured with any available scheduler as noted in the
+`nextflow executors docs <https://www.nextflow.io/docs/latest/executor.html>`_. By default nextflow will use your
+local computer as the 'executor'. The next section briefly walks through nextflow executor configuration to run
 with the slurm job scheduler.
 
-We have prepared a template for ``nextflow.config`` which you can access from the KwanLab/Autometa GitHub repository using this 
-`nextflow.config template <https://raw.githubusercontent.com/KwanLab/Autometa/dev/nextflow.config>`_. Go ahead 
+We have prepared a template for ``nextflow.config`` which you can access from the KwanLab/Autometa GitHub repository using this
+`nextflow.config template <https://raw.githubusercontent.com/KwanLab/Autometa/dev/nextflow.config>`_. Go ahead
 and copy this file to your desired location and open it in your favorite text editor (eg. Vim, nano, VSCode, etc).
 
 
@@ -375,14 +382,14 @@ and copy this file to your desired location and open it in your favorite text ed
 SLURM
 -----
 
-This allows you to run the pipeline using the SLURM resource manager. To do this you'll first needed to identify the 
-slurm partition to use. You can find the available slurm partitions by running ``sinfo``. Example: On running ``sinfo`` 
+This allows you to run the pipeline using the SLURM resource manager. To do this you'll first needed to identify the
+slurm partition to use. You can find the available slurm partitions by running ``sinfo``. Example: On running ``sinfo``
 on our cluster we get the following:
 
 .. image:: ../img/slurm_partitions.png
-    :alt: Screen shot of ``sinfo`` output showing ``queue`` listed under partition  
+    :alt: Screen shot of ``sinfo`` output showing ``queue`` listed under partition
 
-The slurm partition available on our cluster is ``queue``.  You'll need to update this in ``nextflow.config``. 
+The slurm partition available on our cluster is ``queue``.  You'll need to update this in ``nextflow.config``.
 
 .. code-block:: groovy
 
@@ -396,7 +403,7 @@ The slurm partition available on our cluster is ``queue``.  You'll need to updat
     // See https://www.nextflow.io/docs/latest/executor.html#slurm for more details.
     }
 
-More parameters that are available for the slurm executor are listed in the nextflow 
+More parameters that are available for the slurm executor are listed in the nextflow
 `executor docs for slurm <https://www.nextflow.io/docs/latest/executor.html#slurm>`_.
 
 
@@ -404,9 +411,9 @@ Using a different Autometa docker image
 =======================================
 
 
-Especially when developing new features it may be necessary to run the pipeline with a custom docker image. 
-Create a new image by navigating to the top Autometa directory and running ``make image``. This will create a new 
-Autometa Docker image, tagged with the name of the current Git branch. 
+Especially when developing new features it may be necessary to run the pipeline with a custom docker image.
+Create a new image by navigating to the top Autometa directory and running ``make image``. This will create a new
+Autometa Docker image, tagged with the name of the current Git branch.
 
 To use this tagged version (or any other Autometa image tag) add the argument ``--autometa_image tag_name`` to the nextflow run command
 
@@ -421,17 +428,53 @@ running an Autometa *module*.
 
 I.e. ``python -m autometa.common.kmers -h``
 
-Running functions
-=================
+Using Autometa's Python API
+===========================
 
-Many of the Autometa functions may be run standalone as well. It is same as importing any other python
-function.
+Autometa's classes and functions are available after installation.
+To access these, do the same as importing any other python library.
+
+Examples
+--------
+
+samtools wrapper
+~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
     from autometa.common.external import samtools
+    from autometa.common.metagenome import Metagenome
 
-    samtools.sort(sam=<path/to/sam/file>, out=<path/to/output/file>, nproc=4)
+    # To see samtools.sort parameters
+    samtools.sort?
+    # Run samtools sort command in ipython interpreter
+    samtools.sort(sam="<path/to/alignment.sam>", out="<path/to/output/alignment.bam>", cpus=4)
+
+Metagenome Description
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    # To see input parameters, instance attributes and methods
+    Metagenome?
+    # Create a metagenome instance
+    mg = Metagenome(assembly="/path/to/metagenome.fasta")
+    # To see available methods (ignore any elements in the list with a double underscore)
+    dir(mg)
+    # Get pandas dataframe of metagenome details.
+    metagenome_df = mg.describe()
+
+k-mer frequency counting, normalization, embedding
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    # Count kmers
+    counts = kmers.count(assembly="/path/to/metagenome.fasta", size=5)
+    # Normalize kmers
+    norm_df = kmers.normalize(df=counts, method="ilr")
+    # Embed kmers
+    kmers.embed(norm_df, pca_dimensions=50, embed_dimensions=3, method="densmap")
 
 
 .. _nextflow: https://www.nextflow.io/

--- a/docs/source/step-by-step-tutorial.rst
+++ b/docs/source/step-by-step-tutorial.rst
@@ -60,6 +60,8 @@ The above command generates the following files:
 | 78mbp_metagenome.gc_content.tsv | Table of GC content and length of each contig in the filtered assembly |
 +---------------------------------+------------------------------------------------------------------------+
 
+.. _coverage-calculation:
+
 2. Coverage calculation
 -----------------------
 

--- a/main.nf
+++ b/main.nf
@@ -30,8 +30,7 @@ WorkflowMain.initialise(workflow, params, log)
 println """
 --------------------------------------------
 Output files will be found here:
-Intermediate results directory: ${params.interim_dir}
-Binning results directory: ${params.outdir}
+Results directory: ${params.outdir}
 --------------------------------------------
 \n
 """

--- a/main.nf
+++ b/main.nf
@@ -27,19 +27,11 @@ WorkflowMain.initialise(workflow, params, log)
 ////////////////////////////////////////////////////
 
 
-if (params.use_run_name){
-    params.interim_dir_internal = "${params.interim_dir}/autometa_interim_dir/${workflow.runName}/${workflow.sessionId}" // Intermediate results directory
-    params.outdir_internal = "${params.outdir}/autometa_outdir/${workflow.runName}/${workflow.sessionId}"           // Final results directory
-} else {
-    params.interim_dir_internal = "${params.interim_dir}/autometa_interim_dir/${workflow.sessionId}" // Intermediate results directory
-    params.outdir_internal = "${params.outdir}/autometa_outdir/${workflow.sessionId}"           // Final results directory
-}
-
 println """
 --------------------------------------------
 Output files will be found here:
-Intermediate results directory: ${params.interim_dir_internal}
-Binning results directory: ${params.outdir_internal}
+Intermediate results directory: ${params.interim_dir}
+Binning results directory: ${params.outdir}
 --------------------------------------------
 \n
 """

--- a/modules/local/analyze_kmers.nf
+++ b/modules/local/analyze_kmers.nf
@@ -7,17 +7,7 @@ options        = initOptions(params.options)
 process ANALYZE_KMERS {
     tag "Counting kmers for ${meta.id}"
     label 'process_medium'
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -36,7 +26,6 @@ process ANALYZE_KMERS {
         path  '*.version.txt'                        , emit: version
 
     script:
-        // Add soft-links to original FastQs for consistent naming in pipeline
         def software = getSoftwareName(task.process)
         """
         autometa-kmers \\

--- a/modules/local/bedtools_genomecov.nf
+++ b/modules/local/bedtools_genomecov.nf
@@ -7,9 +7,18 @@ options        = initOptions(params.options)
 process BEDTOOLS_GENOMECOV {
     tag "$meta.id"
     label 'process_medium'
-    publishDir "${params.outdir_internal}",
+
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/bedtools_genomecov.nf
+++ b/modules/local/bedtools_genomecov.nf
@@ -5,20 +5,10 @@ params.options = [:]
 options        = initOptions(params.options)
 
 process BEDTOOLS_GENOMECOV {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_medium'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/bin_contigs.nf
+++ b/modules/local/bin_contigs.nf
@@ -7,17 +7,7 @@ options        = initOptions(params.options)
 process BIN_CONTIGS {
     tag "Performing Autometa binning on ${meta.id}"
     label 'process_high'
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/bin_contigs.nf
+++ b/modules/local/bin_contigs.nf
@@ -7,9 +7,17 @@ options        = initOptions(params.options)
 process BIN_CONTIGS {
     tag "Performing Autometa binning on ${meta.id}"
     label 'process_high'
-    publishDir "${params.outdir_internal}",
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -22,8 +30,8 @@ process BIN_CONTIGS {
         tuple val(meta), path(kmers), path(coverage), path(gc_content), path(markers), path(taxonomy)
 
     output:
-        tuple val(meta), path("${meta.id}.${params.kingdom}.binning.tsv.gz"), emit: binning
-        tuple val(meta), path("${meta.id}.${params.kingdom}.main.tsv.gz")   , emit: main
+        tuple val(meta), path("${params.kingdom}.binning.tsv.gz"), emit: binning
+        tuple val(meta), path("${params.kingdom}.main.tsv.gz")   , emit: main
         path  '*.version.txt'                                               , emit: version
 
     script:
@@ -35,8 +43,8 @@ process BIN_CONTIGS {
             --coverages $coverage \\
             --gc-content $gc_content \\
             --markers $markers \\
-            --output-binning ${meta.id}.${params.kingdom}.binning.tsv.gz \\
-            --output-main ${meta.id}.${params.kingdom}.main.tsv.gz \\
+            --output-binning ${params.kingdom}.binning.tsv.gz \\
+            --output-main ${params.kingdom}.main.tsv.gz \\
             --clustering-method ${params.clustering_method} \\
             --completeness ${params.completeness} \\
             --purity ${params.purity} \\

--- a/modules/local/binning_summary.nf
+++ b/modules/local/binning_summary.nf
@@ -9,9 +9,18 @@ params.taxdump_tar_gz_dir =  [:]
 process BINNING_SUMMARY {
     tag "Gathering binning summary for ${meta.id}"
     label 'process_high'
-    publishDir "${params.outdir_internal}",
+
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -25,10 +34,10 @@ process BINNING_SUMMARY {
         val(binning_column)
 
     output:
-        tuple val(meta), path("${meta.id}_metabin_stats.tsv")   , emit: stats
-        tuple val(meta), path("${meta.id}_metabins")            , emit: metabins
-        tuple val(meta), path("${meta.id}_metabin_taxonomy.tsv"), emit: taxonomies, optional: true
-        path  '*.version.txt'                                   , emit: version
+        tuple val(meta), path("metabin_stats.tsv")   , emit: stats
+        tuple val(meta), path("metabins")            , emit: metabins
+        tuple val(meta), path("metabin_taxonomy.tsv"), emit: taxonomies, optional: true
+        path  '*.version.txt'                        , emit: version
 
     script:
         def software = getSoftwareName(task.process)
@@ -39,9 +48,9 @@ process BINNING_SUMMARY {
             --markers $markers \\
             --metagenome $metagenome \\
             --binning-column $binning_column \\
-            --output-stats "${meta.id}_metabin_stats.tsv" \\
-            --output-taxonomy "${meta.id}_metabin_taxonomy.tsv" \\
-            --output-metabins "${meta.id}_metabins"
+            --output-stats "metabin_stats.tsv" \\
+            --output-taxonomy "metabin_taxonomy.tsv" \\
+            --output-metabins "metabins"
 
         echo "TODO" > autometa.version.txt
         """

--- a/modules/local/binning_summary.nf
+++ b/modules/local/binning_summary.nf
@@ -10,17 +10,7 @@ process BINNING_SUMMARY {
     tag "Gathering binning summary for ${meta.id}"
     label 'process_high'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/diamond_blastp.nf
+++ b/modules/local/diamond_blastp.nf
@@ -11,7 +11,7 @@ process DIAMOND_BLASTP {
     // TODO: There appears to be features for multiprocessing available now
     // See: https://github.com/bbuchfink/diamond/wiki/6.-Distributed-computing
     maxForks 1
-    publishDir "${params.interim_dir_internal}",
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
@@ -27,7 +27,7 @@ process DIAMOND_BLASTP {
         path(diamond_database)
 
     output:
-        tuple val(meta), path("${meta.id}.blastp.tsv"), emit: diamond_results
+        tuple val(meta), path("blastp.tsv"), emit: diamond_results
         path "*.version.txt"               , emit: version
 
     script:
@@ -37,7 +37,7 @@ process DIAMOND_BLASTP {
             --query ${protein_fasta} \\
             --db ${diamond_database} \\
             --threads ${task.cpus} \\
-            --out ${meta.id}.blastp.tsv
+            --out blastp.tsv
 
         diamond version | sed 's/^.*diamond version //' > diamond.version.txt
         """

--- a/modules/local/diamond_blastp.nf
+++ b/modules/local/diamond_blastp.nf
@@ -11,9 +11,7 @@ process DIAMOND_BLASTP {
     // TODO: There appears to be features for multiprocessing available now
     // See: https://github.com/bbuchfink/diamond/wiki/6.-Distributed-computing
     maxForks 1
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::diamond=2.0.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/get_genomes_for_mock.nf
+++ b/modules/local/get_genomes_for_mock.nf
@@ -7,6 +7,10 @@ options        = initOptions(params.options)
 process GET_GENOMES_FOR_MOCK {
     def genome_count = options.args2.tokenize('|').size()
     tag "fetching ${genome_count} genomes"
+
+    storeDir = 'mock_data/genomes'
+    cache 'lenient'
+
     conda (params.enable_conda ? "bioconda::emboss=6.6.0" : null)
     container "jasonkwan/autometa-nf-modules-get_genomes_for_mock"
 
@@ -17,6 +21,7 @@ process GET_GENOMES_FOR_MOCK {
         path "assembly_to_locus.txt", emit: assembly_to_locus
         path "assemblies.txt", emit: assemblies
         path "assembly_report.txt", emit: assembly_report
+
     """
     curl -s ${options.args} > assembly_report.txt
 

--- a/modules/local/hmmer_hmmsearch.nf
+++ b/modules/local/hmmer_hmmsearch.nf
@@ -42,7 +42,7 @@ process HMMER_HMMSEARCH {
         def fastacmd = fasta.getExtension() == 'gz' ? "gunzip -c $fasta" : "cat $fasta"
         """
         hmmsearch \\
-            --domtblout "${meta.id}.domtblout" \\
+            --domtblout "${hmm.simpleName}.domtblout" \\
             ${options.args} \\
             ${options.args2} \\
             $hmm \\

--- a/modules/local/hmmer_hmmsearch_filter.nf
+++ b/modules/local/hmmer_hmmsearch_filter.nf
@@ -20,17 +20,7 @@ process HMMER_HMMSEARCH_FILTER {
     // if ( params.num_splits < 2 ) {
     // if running in parallel, the results are published from the process
     // that merges the individual results from this process
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/hmmer_hmmsearch_filter.nf
+++ b/modules/local/hmmer_hmmsearch_filter.nf
@@ -14,16 +14,23 @@ params.options = [:]
 options        = initOptions(params.options)
 
 process HMMER_HMMSEARCH_FILTER {
-    tag "Filtering marker hmms in $meta.id"
+    tag "Filtering marker hmms in ${meta.id}"
     label 'process_medium'
 
-    if ( params.num_splits < 2 ) {
-        // if running in parallel, the results are published from the process
-        // that merges the individual results from this process
-    publishDir "${params.interim_dir_internal}",
+    // if ( params.num_splits < 2 ) {
+    // if running in parallel, the results are published from the process
+    // that merges the individual results from this process
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
-    }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -34,10 +41,10 @@ process HMMER_HMMSEARCH_FILTER {
 
     input:
         tuple val(meta), path(domtblout), path(fasta)
-        path("bacteria.single_copy.cutoffs")
+        path("bacteria.single_copy.cutoffs") // FIXME: This should take cutoffs corresponding to domtblout
 
     output:
-        tuple val(meta), path("${meta.id}.markers.tsv"), emit: markers_tsv
+        tuple val(meta), path("markers.tsv"), emit: markers_tsv
         path "*.version.txt"                           , emit: version
 
     script:
@@ -48,7 +55,7 @@ process HMMER_HMMSEARCH_FILTER {
             --domtblout "$domtblout" \\
             --cutoffs  TODO:"Cutoffs" need to be downloaded/provided to this process \\
             --seqdb "$fasta" \\
-            --out "${meta.id}.markers.tsv"
+            --out "markers.tsv"
 
         echo "TODO" > autometa.version.txt
         """

--- a/modules/local/length_table.nf
+++ b/modules/local/length_table.nf
@@ -5,20 +5,10 @@ params.options = [:]
 options        = initOptions(params.options)
 
 process LENGTH_TABLE {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_low'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/length_table.nf
+++ b/modules/local/length_table.nf
@@ -7,9 +7,18 @@ options        = initOptions(params.options)
 process LENGTH_TABLE {
     tag "$meta.id"
     label 'process_low'
-    publishDir "${params.outdir_internal}",
+
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -22,8 +31,8 @@ process LENGTH_TABLE {
         tuple val(meta), path(metagenome)
 
     output:
-        tuple val(meta), path("${meta.id}.lengths.tsv"), emit: lengths
-        path  '*.version.txt'                          , emit: version
+        tuple val(meta), path("lengths.tsv"), emit: lengths
+        path  '*.version.txt'               , emit: version
 
     script:
         def software = getSoftwareName(task.process)
@@ -35,7 +44,7 @@ process LENGTH_TABLE {
         seqs = {record.id: len(record.seq) for record in SeqIO.parse(${metagenome}, "fasta")}
         lengths = pd.Series(seqs, name="length")
         lengths.index.name = "contig"
-        lengths.to_csv(${meta.id}.lengths.tsv, sep="\t", index=True, header=True)
+        lengths.to_csv(lengths.tsv, sep="\t", index=True, header=True)
 
         echo "TODO" > ${software}.version.txt
         """

--- a/modules/local/majority_vote.nf
+++ b/modules/local/majority_vote.nf
@@ -9,7 +9,7 @@ process MAJORITY_VOTE {
     label 'process_medium'
 
     tag "Performing taxon majority vote on ${meta.id}"
-    publishDir "${params.interim_dir_internal}",
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
@@ -25,13 +25,13 @@ process MAJORITY_VOTE {
         path(ncbi_tax_dir)
 
     output:
-        tuple val(meta), path("${meta.id}.votes.tsv"), emit: votes
-        path  '*.version.txt'                        , emit: version
+        tuple val(meta), path("votes.tsv"), emit: votes
+        path  '*.version.txt'             , emit: version
 
     script:
         def software = getSoftwareName(task.process)
         """
-        autometa-taxonomy-majority-vote --lca ${lca} --output ${meta.id}.votes.tsv --dbdir "${ncbi_tax_dir}"
+        autometa-taxonomy-majority-vote --lca ${lca} --output votes.tsv --dbdir "${ncbi_tax_dir}"
 
         echo "TODO" > autometa.version.txt
         """

--- a/modules/local/majority_vote.nf
+++ b/modules/local/majority_vote.nf
@@ -6,12 +6,9 @@ options        = initOptions(params.options)
 
 
 process MAJORITY_VOTE {
-    label 'process_medium'
-
     tag "Performing taxon majority vote on ${meta.id}"
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+    label 'process_medium'
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/markers.nf
+++ b/modules/local/markers.nf
@@ -4,10 +4,22 @@ include { initOptions; saveFiles; getSoftwareName } from './functions'
 params.options = [:]
 options        = initOptions(params.options)
 
-// TODO: For faster results/ les I/O this could be replaced with hmmsearch
+// TODO: For faster results/ less I/O this could be replaced with hmmsearch
 process MARKERS {
     tag "Finding markers for ${meta.id}"
     label "process_low"
+
+    publishDir "${meta.id}",
+        mode: params.publish_dir_mode,
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -22,8 +34,9 @@ process MARKERS {
         //path(cutoffs) currently only inside docker
 
     output:
-        tuple val(meta), path("${meta.id}.markers.tsv"), emit: markers_tsv
-        path  '*.version.txt'                          , emit: version
+        tuple val(meta), path("${params.kingdom}.markers.tsv"), emit: markers_tsv
+        tuple val(meta), path("${params.kingdom}.hmmscan.tsv"), emit: hmscan_tsv
+        path  '*.version.txt'               , emit: version
 
     script:
         def software = getSoftwareName(task.process)
@@ -35,8 +48,8 @@ process MARKERS {
         """
         autometa-markers \\
             --orfs $orfs \\
-            --hmmscan ${meta.id}.hmmscan.tsv \\
-            --out ${meta.id}.markers.tsv \\
+            --hmmscan ${params.kingdom}.hmmscan.tsv \\
+            --out ${params.kingdom}.markers.tsv \\
             --kingdom ${params.kingdom} \\
             --parallel \\
             --cpus ${task.cpus} \\

--- a/modules/local/markers.nf
+++ b/modules/local/markers.nf
@@ -9,17 +9,7 @@ process MARKERS {
     tag "Finding markers for ${meta.id}"
     label "process_low"
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/merge_fasta.nf
+++ b/modules/local/merge_fasta.nf
@@ -8,17 +8,7 @@ process MERGE_FASTA {
     tag "Merging ${meta.id} FASTA"
     label 'process_low'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::seqkit=0.16.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/merge_fasta.nf
+++ b/modules/local/merge_fasta.nf
@@ -7,9 +7,18 @@ options        = initOptions(params.options)
 process MERGE_FASTA {
     tag "Merging ${meta.id} FASTA"
     label 'process_low'
-    publishDir "${params.interim_dir_internal}",
+
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "bioconda::seqkit=0.16.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/merge_tsv.nf
+++ b/modules/local/merge_tsv.nf
@@ -7,9 +7,18 @@ options        = initOptions(params.options)
 process MERGE_TSV_WITH_HEADERS {
     tag "Merging files from parallel split for ${meta.id}"
     label 'process_low'
-    publishDir "${params.interim_dir_internal}",
+
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
 

--- a/modules/local/merge_tsv.nf
+++ b/modules/local/merge_tsv.nf
@@ -8,17 +8,7 @@ process MERGE_TSV_WITH_HEADERS {
     tag "Merging files from parallel split for ${meta.id}"
     label 'process_low'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
 

--- a/modules/local/mock_data_reporter.nf
+++ b/modules/local/mock_data_reporter.nf
@@ -9,8 +9,7 @@ process MOCK_DATA_REPORT {
     tag 'Preparing mock data report'
     label 'process_low'
 
-    publishDir "${options.publish_dir}",
-      mode: params.publish_dir_mode
+    publishDir "${options.publish_dir}", mode: params.publish_dir_mode
 
     container "jasonkwan/autometa-nf-modules-mock_data_reporter"
 

--- a/modules/local/mock_data_reporter.nf
+++ b/modules/local/mock_data_reporter.nf
@@ -9,7 +9,7 @@ process MOCK_DATA_REPORT {
     tag 'Preparing mock data report'
     label 'process_low'
 
-    publishDir "${params.outdir_internal}/${options.publish_dir}",
+    publishDir "${options.publish_dir}",
       mode: params.publish_dir_mode
 
     container "jasonkwan/autometa-nf-modules-mock_data_reporter"

--- a/modules/local/parse_bed.nf
+++ b/modules/local/parse_bed.nf
@@ -8,17 +8,7 @@ process PARSE_BED {
     tag "$meta.id"
     label 'process_low'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/parse_bed.nf
+++ b/modules/local/parse_bed.nf
@@ -7,9 +7,18 @@ options        = initOptions(params.options)
 process PARSE_BED {
     tag "$meta.id"
     label 'process_low'
-    publishDir "${params.outdir_internal}",
+
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -22,8 +31,8 @@ process PARSE_BED {
         tuple val(meta), path(bam), path(lengths), path(bed_out)
 
     output:
-        tuple val(meta), path("${meta.id}.coverage.tsv"), emit: coverage
-        path  "*.version.txt"                           , emit: version
+        tuple val(meta), path("coverage.tsv"), emit: coverage
+        path  "*.version.txt"                , emit: version
 
     script:
         def software = getSoftwareName(task.process)
@@ -32,7 +41,7 @@ process PARSE_BED {
             --ibam $bam \\
             --lengths $lengths \\
             --bed $bed_out \\
-            --output ${meta.id}.coverage.tsv
+            --output coverage.tsv
 
         echo "TODO" > autometa.version.txt
         """

--- a/modules/local/prepare_lca.nf
+++ b/modules/local/prepare_lca.nf
@@ -7,9 +7,6 @@ options        = initOptions(params.options)
 process PREPARE_LCA {
     tag "Preparing db cache from ${blastdb_dir}"
     label 'process_medium'
-    publishDir "${params.interim_dir_internal}",
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -25,7 +22,7 @@ process PREPARE_LCA {
         path(blastdb_dir)
 
     output:
-        path "cache"       , emit: cache
+        path "cache"           , emit: cache
         path '*.version.txt'   , emit: version
 
     script:

--- a/modules/local/reduce_lca.nf
+++ b/modules/local/reduce_lca.nf
@@ -6,10 +6,9 @@ options        = initOptions(params.options)
 
 process REDUCE_LCA {
     tag "Finding LCA for ${meta.id}"
-    label 'process_high'
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+    label 'process_medium'
+
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/reduce_lca.nf
+++ b/modules/local/reduce_lca.nf
@@ -7,7 +7,7 @@ options        = initOptions(params.options)
 process REDUCE_LCA {
     tag "Finding LCA for ${meta.id}"
     label 'process_high'
-    publishDir "${params.interim_dir_internal}",
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
@@ -24,10 +24,10 @@ process REDUCE_LCA {
         path(lca_cache)
 
     output:
-        tuple val(meta), path("${meta.id}.lca.tsv"), emit: lca
-        path "${meta.id}.error_taxids.tsv"         , emit: error_taxids
-        path "${meta.id}.sseqid2taxid.tsv"         , emit: sseqid_to_taxids
-        path '*.version.txt'                       , emit: version
+        tuple val(meta), path("lca.tsv"), emit: lca
+        path "lca_error_taxids.tsv"     , emit: error_taxids
+        path "sseqid2taxid.tsv"         , emit: sseqid_to_taxids
+        path '*.version.txt'            , emit: version
 
 
     script:
@@ -37,9 +37,9 @@ process REDUCE_LCA {
             --blast ${blast} \\
             --dbdir ${blastdb_dir} \\
             --cache ${lca_cache} \\
-            --lca-error-taxids ${meta.id}.error_taxids.tsv \\
-            --sseqid2taxid-output ${meta.id}.sseqid2taxid.tsv \\
-            --lca-output ${meta.id}.lca.tsv
+            --lca-error-taxids lca_error_taxids.tsv \\
+            --sseqid2taxid-output sseqid2taxid.tsv \\
+            --lca-output lca.tsv
         echo "TODO" > autometa.version.txt
         """
 }

--- a/modules/local/samtools_view_sort.nf
+++ b/modules/local/samtools_view_sort.nf
@@ -7,9 +7,18 @@ options        = initOptions(params.options)
 process SAMTOOLS_VIEW_AND_SORT {
     tag "$meta.id"
     label 'process_medium'
-    publishDir "${params.outdir_internal}",
+
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "bioconda::samtools=1.13" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/samtools_view_sort.nf
+++ b/modules/local/samtools_view_sort.nf
@@ -8,17 +8,7 @@ process SAMTOOLS_VIEW_AND_SORT {
     tag "$meta.id"
     label 'process_medium'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::samtools=1.13" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/seqkit_filter.nf
+++ b/modules/local/seqkit_filter.nf
@@ -8,17 +8,7 @@ process SEQKIT_FILTER {
     tag "Removing contigs < ${params.length_cutoff} bp, from ${meta.id}"
     label 'process_high'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::seqkit=0.16.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/seqkit_split.nf
+++ b/modules/local/seqkit_split.nf
@@ -8,8 +8,6 @@ process SEQKIT_SPLIT {
     tag "Splitting $meta.id for parallel processing"
     label 'process_medium'
 
-    // no publishdir
-
     conda (params.enable_conda ? "bioconda::seqkit=0.16.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/seqkit:0.16.1--h9ee0642_0"

--- a/modules/local/spades_kmer_coverage.nf
+++ b/modules/local/spades_kmer_coverage.nf
@@ -8,17 +8,7 @@ process SPADES_KMER_COVERAGE {
     tag "${meta.id}"
     label 'process_low'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/spades_kmer_coverage.nf
+++ b/modules/local/spades_kmer_coverage.nf
@@ -5,12 +5,20 @@ params.options = [:]
 options        = initOptions(params.options)
 
 process SPADES_KMER_COVERAGE {
-    tag "Calculating k-mer coverage for ${meta.id}"
+    tag "${meta.id}"
     label 'process_low'
 
-    publishDir "${params.interim_dir_internal}",
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -23,8 +31,8 @@ process SPADES_KMER_COVERAGE {
         tuple val(meta), path(metagenome)
 
     output:
-        tuple val(meta), path("${meta.id}.coverage")     , emit: coverages
-        path  '*.version.txt'                            , emit: version
+        tuple val(meta), path("coverage.tsv")     , emit: coverages
+        path  '*.version.txt'                     , emit: version
 
     script:
         def software = getSoftwareName(task.process)
@@ -32,7 +40,7 @@ process SPADES_KMER_COVERAGE {
         autometa-coverage \\
             --assembly ${metagenome} \\
             --from-spades \\
-            --out "${meta.id}.coverage"
+            --out "coverage.tsv"
 
         echo "TODO" > autometa.version.txt
         """

--- a/modules/local/split_kingdoms.nf
+++ b/modules/local/split_kingdoms.nf
@@ -8,7 +8,7 @@ process SPLIT_KINGDOMS {
     tag "Splitting votes into kingdoms for ${meta.id}"
     label 'process_medium'
 
-    publishDir "${params.interim_dir_internal}",
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
@@ -24,10 +24,10 @@ process SPLIT_KINGDOMS {
         path(ncbi_tax_dir)
 
     output:
-        tuple val(meta), path("${meta.id}.taxonomy.tsv"), emit: taxonomy
-        tuple val(meta), path("${meta.id}.bacteria.fna"), emit: bacteria, optional: true
-        tuple val(meta), path("${meta.id}.archaea.fna") , emit: archaea, optional: true
-        path  '*.version.txt'                           , emit: version
+        tuple val(meta), path("taxonomy.tsv"), emit: taxonomy
+        tuple val(meta), path("bacteria.fna"), emit: bacteria, optional: true
+        tuple val(meta), path("archaea.fna") , emit: archaea, optional: true
+        path  '*.version.txt'                , emit: version
 
     script:
         def software = getSoftwareName(task.process)
@@ -35,7 +35,6 @@ process SPLIT_KINGDOMS {
         autometa-taxonomy \\
             --votes "${votes}" \\
             --output . \\
-            --prefix "${meta.id}" \\
             --split-rank-and-write superkingdom \\
             --assembly "${assembly}" \\
             --ncbi "${ncbi_tax_dir}"

--- a/modules/local/split_kingdoms.nf
+++ b/modules/local/split_kingdoms.nf
@@ -8,9 +8,7 @@ process SPLIT_KINGDOMS {
     tag "Splitting votes into kingdoms for ${meta.id}"
     label 'process_medium'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "bioconda::autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/unclustered_recruitment.nf
+++ b/modules/local/unclustered_recruitment.nf
@@ -8,17 +8,7 @@ process RECRUIT {
     tag "Performing Autometa unclustered recruitment on ${meta.id}"
     label 'process_high'
 
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
     conda (params.enable_conda ? "autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/local/unclustered_recruitment.nf
+++ b/modules/local/unclustered_recruitment.nf
@@ -8,9 +8,17 @@ process RECRUIT {
     tag "Performing Autometa unclustered recruitment on ${meta.id}"
     label 'process_high'
 
-    publishDir "${params.outdir_internal}",
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
 
     conda (params.enable_conda ? "autometa" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -23,9 +31,9 @@ process RECRUIT {
         tuple val(meta), path(kmers), path(coverage), path(binning), path(markers), path(taxonomy)
 
     output:
-        tuple val(meta), path ("${meta.id}.${params.kingdom}.recruitment.tsv.gz")     , emit: binning, optional: true
-        tuple val(meta), path ("${meta.id}.${params.kingdom}.recruitment.main.tsv.gz"), emit: main, optional: true
-        path  '*.version.txt'                                                         , emit: version
+        tuple val(meta), path ("${params.kingdom}.recruitment.tsv.gz")     , emit: binning, optional: true
+        tuple val(meta), path ("${params.kingdom}.recruitment.main.tsv.gz"), emit: main, optional: true
+        path  '*.version.txt'                                              , emit: version
 
     script:
         // Add soft-links to original FastQs for consistent naming in pipeline
@@ -40,8 +48,8 @@ process RECRUIT {
             --coverage $coverage \\
             --binning $binning \\
             --markers $markers \\
-            --output-binning ${meta.id}.${params.kingdom}.recruitment.tsv.gz \\
-            --output-main ${meta.id}.${params.kingdom}.recruitment.main.tsv.gz
+            --output-binning ${params.kingdom}.recruitment.tsv.gz \\
+            --output-main ${params.kingdom}.recruitment.main.tsv.gz
         echo "TODO" > autometa.version.txt
         """
         else
@@ -55,8 +63,8 @@ process RECRUIT {
             --coverage $coverage \\
             --binning $binning \\
             --markers $markers \\
-            --output-binning ${meta.id}.${params.kingdom}.recruitment.tsv.gz \\
-            --output-main ${meta.id}.${params.kingdom}.recruitment.main.tsv.gz
+            --output-binning ${params.kingdom}.recruitment.tsv.gz \\
+            --output-main ${params.kingdom}.recruitment.main.tsv.gz
 
         echo "TODO" > autometa.version.txt
         """

--- a/modules/nf-core/modules/prodigal/main.nf
+++ b/modules/nf-core/modules/prodigal/main.nf
@@ -7,9 +7,18 @@ options        = initOptions(params.options)
 process PRODIGAL {
     tag "Annotating $meta.id"
     label 'process_low'
-    publishDir "${params.interim_dir_internal}",
+    publishDir "${meta.id}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: {
+            filename -> saveFiles(
+                filename:filename,
+                options:params.options,
+                publish_dir:getSoftwareName(task.process),
+                meta:[:],
+                publish_by_meta:[]
+            )
+        }
+
 
     conda (params.enable_conda ? "bioconda::prodigal=2.6.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/modules/nf-core/modules/prodigal/main.nf
+++ b/modules/nf-core/modules/prodigal/main.nf
@@ -7,17 +7,7 @@ options        = initOptions(params.options)
 process PRODIGAL {
     tag "Annotating $meta.id"
     label 'process_low'
-    publishDir "${meta.id}",
-        mode: params.publish_dir_mode,
-        saveAs: {
-            filename -> saveFiles(
-                filename:filename,
-                options:params.options,
-                publish_dir:getSoftwareName(task.process),
-                meta:[:],
-                publish_by_meta:[]
-            )
-        }
+    publishDir "${params.outdir}/${meta.id}", mode: params.publish_dir_mode
 
 
     conda (params.enable_conda ? "bioconda::prodigal=2.6.3" : null)
@@ -32,23 +22,22 @@ process PRODIGAL {
     val(output_format)
 
     output:
-    tuple val(meta), path("${prefix}.${output_format}"), emit: gene_annotations
-    tuple val(meta), path("${prefix}.fna"), emit: nucleotide_fasta
-    tuple val(meta), path("${prefix}.faa"), emit: amino_acid_fasta
-    tuple val(meta), path("${prefix}_all.txt"), emit: all_gene_annotations
+    tuple val(meta), path("orfs.${output_format}"), emit: gene_annotations
+    tuple val(meta), path("orfs.fna"), emit: nucleotide_fasta
+    tuple val(meta), path("orfs.faa"), emit: amino_acid_fasta
+    tuple val(meta), path("orfs_all.txt"), emit: all_gene_annotations
     path "*.version.txt"          , emit: version
 
     script:
     def software = getSoftwareName(task.process)
-    prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     """
     prodigal -i ${genome} \\
         $options.args \\
         -f $output_format \\
-        -d "${prefix}.fna" \\
-        -o "${prefix}.${output_format}" \\
-        -a "${prefix}.faa" \\
-        -s "${prefix}_all.txt" 
+        -d "orfs.fna" \\
+        -o "orfs.${output_format}" \\
+        -a "orfs.faa" \\
+        -s "orfs_all.txt" 
 
     echo \$(prodigal -v 2>&1) | sed -n 's/Prodigal V\\(.*\\):.*/\\1/p' > ${software}.version.txt
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,7 +37,7 @@ params {
 
     // Input options
     input                      = null // Metagenome path (.fna)
-    outdir                     = "${baseDir}"
+    outdir                     = "autometa-nxf-output"
 
 /*
  * -------------------------------------------------

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,8 +38,6 @@ params {
     // Input options
     input                      = null // Metagenome path (.fna)
     outdir                     = "${baseDir}"
-    interim_dir                = "${baseDir}"
-    tracedir                   = "${baseDir}/autometa_tracedir"
 
 /*
  * -------------------------------------------------
@@ -57,7 +55,7 @@ params {
 
 /*
  * -------------------------------------------------
- *  Binning Paramaters
+ *  Binning Parameters
  * -------------------------------------------------
 */
 
@@ -85,14 +83,14 @@ params {
     publish_dir_mode                  = 'copy'
     email                             = null
     email_on_fail                     = null
-    plaintext_email                   = false
+    plaintext_email                   = null
     monochrome_logs                   = false
     help                              = false
     validate_params                   = true
-    show_hidden_params                = false
+    show_hidden_params                = null
     schema_ignore_params              = 'genomes,modules'
     enable_conda                      = false
-    singularity_pull_docker_container = false
+    singularity_pull_docker_container = null
 
     // Config options
     custom_config_version      = 'master'
@@ -112,6 +110,8 @@ params {
     num_splits = 1
 
 }
+
+params.tracedir = "${params.outdir}/trace"
 
 
 // Load base.config by default for all pipelines
@@ -141,7 +141,7 @@ profiles {
     }
     slurm {
     	process.executer       = "slurm"
-	// NOTE: You can determine your slurm partition (e.g. process.queue) with the `sinfo` command
+	    // NOTE: You can determine your slurm partition (e.g. process.queue) with the `sinfo` command
     	process.queue          = "queue"
         docker.enabled         = true
         docker.userEmulation   = true
@@ -215,19 +215,19 @@ process.shell = ['/bin/bash', '-euo', 'pipefail']
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {
     enabled = true
-    file    = "${params.tracedir}/execution_timeline_${trace_timestamp}.html"
+    file    = "${params.outdir}/trace/execution_timeline_${trace_timestamp}.html"
 }
 report {
     enabled = true
-    file    = "${params.tracedir}/execution_report_${trace_timestamp}.html"
+    file    = "${params.outdir}/trace/execution_report_${trace_timestamp}.html"
 }
 trace {
     enabled = true
-    file    = "${params.tracedir}/execution_trace_${trace_timestamp}.txt"
+    file    = "${params.outdir}/trace/execution_trace_${trace_timestamp}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.tracedir}/pipeline_dag_${trace_timestamp}.svg"
+    file    = "${params.outdir}/trace/pipeline_dag_${trace_timestamp}.svg"
 }
 
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -22,13 +22,6 @@
                     "help_text": "Use this to specify the location of your input FASTA files. For example:\n\nA single FASTA file: \n```bash\n--input path/to/data/sample.fna\n```\n\nMultiple FASTA files: \n\n```bash\n--input path/to/data/sample_*.fna\n```\n\nNote:\nDo not surround with quotes",
                     "default": "null"
                 },
-                "interim_dir": {
-                    "type": "string",
-                    "description": "Absolute (full) path of directory for intermediate files",
-                    "default": "~/where/pipeline/is/launched",
-                    "fa_icon": "fas fa-folder-open",
-                    "help_text": "Directory for storing files created during intermediate steps but which are interesting enough to keep for debugging or analyzing with other tools"
-                },
                 "outdir": {
                     "type": "string",
                     "description": "Absolute (full) path of directory where the results will be saved.",
@@ -38,7 +31,7 @@
                 "tracedir": {
                     "type": "string",
                     "description": "Absolute (full) path of directory to keep pipeline Nextflow logs and reports.",
-                    "default": "~/where/pipeline/is/launched",
+                    "default": "outdir/trace",
                     "fa_icon": "fas fa-cogs"
                 },
                 "publish_dir_mode": {
@@ -72,7 +65,7 @@
                 "embedding_method": {
                     "type": "string",
                     "default": "bhsne",
-                    "description": "Embedding method to use. Choices are \"sksne\", \"bhsne\", \"umap\", \"densne\", \"trimap\""
+                    "description": "Embedding method to use. Choices are \"sksne\", \"bhsne\", \"umap\", \"densmap\", \"trimap\""
                 },
                 "embedding_dimensions": {
                     "type": "integer",
@@ -240,7 +233,7 @@
                     "type": "string",
                     "default": "latest",
                     "description": "Change which tag of the autometa docker image is used",
-                    "help_text": "Appends input to `jason-c-kwan/autometa`\n\njason-c-kwan/autometa:${params.autometa_image_tag}\""
+                    "help_text": "Appends input to `jasonkwan/autometa`\n\njasonkwan/autometa:${params.autometa_image_tag}\""
                 }
             },
             "required": [
@@ -341,24 +334,6 @@
             "required": [
                 "validate_params"
             ]
-        },
-        "parameters_set_internally": {
-            "title": "Parameters set internally",
-            "type": "object",
-            "description": "These parameters are determined during runtime",
-            "default": "",
-            "properties": {
-                "outdir_internal": {
-                    "type": "string",
-                    "hidden": true,
-                    "description": "These parameters are determined during runtime"
-                },
-                "interim_dir_internal": {
-                    "type": "string",
-                    "hidden": true,
-                    "description": "These parameters are determined during runtime"
-                }
-            }
         }
     },
     "allOf": [
@@ -376,9 +351,6 @@
         },
         {
             "$ref": "#/definitions/generic_nf_core_options"
-        },
-        {
-            "$ref": "#/definitions/parameters_set_internally"
         }
     ]
 }

--- a/subworkflows/local/lca.nf
+++ b/subworkflows/local/lca.nf
@@ -34,7 +34,6 @@ workflow LCA {
 /*
 ---------------: Test Command :-----------------
 nextflow run -resume $HOME/Autometa/subworkflows/local/lca.nf \\
-    --interim_dir_internal nf-test \\
     --publish_dir_mode copy \\
     --input '/path/to/*.blastp.tsv' \\
     --dbdir '/path/to/ncbi/databases/directory'

--- a/subworkflows/local/mock_data.nf
+++ b/subworkflows/local/mock_data.nf
@@ -42,21 +42,21 @@ workflow CREATE_MOCK {
         GET_GENOMES_FOR_MOCK.out.fake_spades_coverage
         .map { row ->
                     def meta = [:]
-                    meta.id = 'mock_data'
+                    meta.id = "mock_data"
                     return [ meta, row ]
             }
         .set { ch_fasta }
         GET_GENOMES_FOR_MOCK.out.assembly_to_locus
         .map { row ->
                     def meta = [:]
-                    meta.id = 'mock_data'
+                    meta.id = "mock_data"
                     return [ meta, row ]
             }
         .set { assembly_to_locus }
         GET_GENOMES_FOR_MOCK.out.assembly_report
         .map { row ->
                     def meta = [:]
-                    meta.id = 'mock_data'
+                    meta.id = "mock_data"
                     return [ meta, row ]
             }
         .set { assembly_report }
@@ -65,5 +65,5 @@ workflow CREATE_MOCK {
         fasta = ch_fasta
         reads = SAMTOOLS_WGSIM.out.fastq
         assembly_to_locus = assembly_to_locus
-        assembly_report =   assembly_report
+        assembly_report = assembly_report
 }

--- a/workflows/autometa.nf
+++ b/workflows/autometa.nf
@@ -118,7 +118,7 @@ workflow AUTOMETA {
         fasta_ch
     )
 
-    if ( params.num_splits > 0 ) {
+    if ( params.num_splits > 1 ) {
         MERGE_SPADES_COVERAGE_TSV (
             SPADES_KMER_COVERAGE.out.coverages.groupTuple(),
             "coverage"
@@ -143,7 +143,7 @@ workflow AUTOMETA {
         "gbk"
     )
 
-    if ( params.num_splits > 0 ) {
+    if ( params.num_splits > 1 ) {
         MERGE_PRODIGAL (
             PRODIGAL.out.amino_acid_fasta.groupTuple(),
             "faa"
@@ -201,7 +201,7 @@ workflow AUTOMETA {
     //       .set{hmmsearch_out}
     // HMMER_HMMSEARCH_FILTER(hmmsearch_out)
     MARKERS(PRODIGAL.out.amino_acid_fasta)
-    if ( params.num_splits > 0 ) {
+    if ( params.num_splits > 1 ) {
         MERGE_HMMSEARCH (
             MARKERS.out.markers_tsv.groupTuple(),
             "markers.tsv"


### PR DESCRIPTION
Nextflow output structure now resembles what was discussed in #160. Note, metagenomes are not enumerated for generation of their output directory name, their `meta.id` is used which is the `metagenome.simpleName` (groovy method) from the respective input metagenome. This clobbers filenames with multiple `.`. For example, the `meta.id` of `my.example.metagenome.fasta` would be `my`. Moving forward (looking at #186), altering the input s.t. a sample sheet is provided would use values in this table to check for unique sample IDs to write each sample to its respective sample ID results directory.

- 🍏  fixes #160
- :memo: Update running Autometa documentation
  - :fire: Remove trailing whitespaces
  - :art: Change some of the note card headers to attention and caution cards
- :fire: Remove redundancies in main autometa workflow
- 🍏  Add `storeDir` for fetching mock_data genomes
- 🍏 🛠️ :bug: `hmmsearch` nf processes still need to be fixed
- :fire: Remove unused parameters in `nextflow_schema.json`
- :fire::art: Fix `nextflow.config` nf-core settings to silence linter warnings