### PR TITLE
Add error handling strategies for nextflow processes

### DIFF
--- a/autometa/common/markers.py
+++ b/autometa/common/markers.py
@@ -278,4 +278,10 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+
+    try:
+        main()
+    except AssertionError as err:
+        logger.warn(err)
+        sys.exit(204)

--- a/autometa/common/markers.py
+++ b/autometa/common/markers.py
@@ -10,6 +10,7 @@ marker sets depending on sequence set taxonomy
 
 import logging
 import os
+import sys
 
 import pandas as pd
 
@@ -261,27 +262,25 @@ def main():
     )
     args = parser.parse_args()
 
-    get(
-        kingdom=args.kingdom,
-        orfs=args.orfs,
-        hmmdb=args.hmmdb,
-        dbdir=args.dbdir,
-        cutoffs=args.cutoffs,
-        scans=args.hmmscan,
-        out=args.out,
-        force=args.force,
-        cpus=args.cpus,
-        parallel=args.parallel,
-        gnu_parallel=args.gnu_parallel,
-        seed=args.seed,
-    )
-
-
-if __name__ == "__main__":
-    import sys
-
     try:
-        main()
+        get(
+            kingdom=args.kingdom,
+            orfs=args.orfs,
+            hmmdb=args.hmmdb,
+            dbdir=args.dbdir,
+            cutoffs=args.cutoffs,
+            scans=args.hmmscan,
+            out=args.out,
+            force=args.force,
+            cpus=args.cpus,
+            parallel=args.parallel,
+            gnu_parallel=args.gnu_parallel,
+            seed=args.seed,
+        )
     except AssertionError as err:
         logger.warn(err)
         sys.exit(204)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/local/embed_kmers.nf
+++ b/modules/local/embed_kmers.nf
@@ -16,6 +16,9 @@ process EMBED_KMERS {
         container "jasonkwan/autometa:${params.autometa_image_tag}"
     }
 
+    // Not enough contigs to perform embedding with current parameter settings...
+    errorStrategy { task.exitStatus in 153 ? 'ignore' : 'terminate' }
+
     input:
         tuple val(meta), path(normalized)
 

--- a/modules/local/markers.nf
+++ b/modules/local/markers.nf
@@ -18,6 +18,9 @@ process MARKERS {
         container "jasonkwan/autometa:${params.autometa_image_tag}"
     }
 
+    // No markers in kingdom.hmmscan.tsv pass cutoff thresholds
+    errorStrategy { task.exitStatus in 204 ? 'ignore' : 'terminate' }
+
     input:
         tuple val(meta), path(orfs)
         //path(hmmdb) currently only inside docker

--- a/subworkflows/local/lca.nf
+++ b/subworkflows/local/lca.nf
@@ -4,8 +4,8 @@ nextflow.enable.dsl=2
 params.prepare_lca_options  = [:]
 params.reduce_lca_options    = [:]
 
-include { PREPARE_LCA    } from './../../modules/local/prepare_lca.nf' addParams( options: params.prepare_lca_options )
-include { REDUCE_LCA     } from './../../modules/local/reduce_lca.nf'  addParams( options: params.reduce_lca_options )
+include { PREPARE_LCA as PREP_DBS } from './../../modules/local/prepare_lca.nf' addParams( options: params.prepare_lca_options )
+include { REDUCE_LCA as REDUCE    } from './../../modules/local/reduce_lca.nf'  addParams( options: params.reduce_lca_options )
 
 
 workflow LCA {
@@ -15,20 +15,20 @@ workflow LCA {
         blastp_dbdir
 
     main:
-        PREPARE_LCA(
+        PREP_DBS(
             blastp_dbdir
         )
-        REDUCE_LCA(
+        REDUCE(
             blastp_results,
             blastp_dbdir,
-            PREPARE_LCA.out.cache
+            PREP_DBS.out.cache
         )
 
     emit:
-        lca = REDUCE_LCA.out.lca
-        error_taxid = REDUCE_LCA.out.error_taxids
-        sseqid_to_taxids = REDUCE_LCA.out.sseqid_to_taxids
-        cache  = PREPARE_LCA.out.cache
+        lca = REDUCE.out.lca
+        error_taxid = REDUCE.out.error_taxids
+        sseqid_to_taxids = REDUCE.out.sseqid_to_taxids
+        cache  = PREP_DBS.out.cache
 }
 
 /*

--- a/tests/unit_tests/test_recursive_dbscan.py
+++ b/tests/unit_tests/test_recursive_dbscan.py
@@ -264,5 +264,7 @@ def test_recursive_dbscan_main_tableformaterror(
         return MockParser()
 
     monkeypatch.setattr(argparse, "ArgumentParser", return_mock_parser, raising=True)
-    with pytest.raises(TableFormatError):
+    with pytest.raises(SystemExit) as err:
         recursive_dbscan.main()
+    assert err.type == SystemExit
+    assert err.value.code == 204


### PR DESCRIPTION
Add error handling strategies for nextflow processes

1. embed_kmers.nf
        - errorStrategy {exitCode in 153 ? "ignore" : "terminate" }
        - Not enough contigs to perform embedding with current parameter settings
2. binning.nf
        - errorStrategy { task.exitStatus in 204 ? 'ignore' : 'terminate' }
        - No markers were annotated for contigs in the table
3. unclustered_recruitment.nf
        - errorStrategy { task.exitStatus in 204 ? 'ignore' : 'terminate' }
        - No markers were annotated for contigs in the table
4. markers.nf
        - errorStrategy { task.exitStatus in 204 ? 'ignore' : 'terminate' }
        - No markers in `kingdom.hmmscan.tsv` pass cutoff thresholds