### PR TITLE
GH action: Add dynamic docker tags

### DIFF
--- a/.github/workflows/docker_autometa.yml
+++ b/.github/workflows/docker_autometa.yml
@@ -2,13 +2,14 @@ name: docker Autometa CI/CD
 
 on:
   push:
+    paths-ignore:
+      - "docs/**"
     branches:
       - main
       - dev
-    tags:
-      - type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-      - type=semver,pattern={{version}}
   pull_request:
+    paths-ignore:
+      - "docs/**"
     branches:
       - main
       - dev
@@ -28,6 +29,9 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: jasonkwan/autometa
+          tags: |
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=semver,pattern={{version}}
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1

--- a/.github/workflows/docker_autometa.yml
+++ b/.github/workflows/docker_autometa.yml
@@ -31,6 +31,7 @@ jobs:
           images: jasonkwan/autometa
           tags: |
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value={{branch}},enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
             type=semver,pattern={{version}}
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker_autometa.yml
+++ b/.github/workflows/docker_autometa.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - dev
+    tags:
+      - type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+      - type=semver,pattern={{version}}
   pull_request:
     branches:
       - main

--- a/.github/workflows/docker_autometa.yml
+++ b/.github/workflows/docker_autometa.yml
@@ -31,7 +31,7 @@ jobs:
           images: jasonkwan/autometa
           tags: |
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-            type=raw,value={{branch}},enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value={{branch}}
             type=semver,pattern={{version}}
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ docker run -it --rm jasonkwan/autometa:main
 #### Install into current env
 
 ```bash
-conda install -c bioconda -c conda-forge nextflow>=20.10 nf-core==2.1
+conda env update -n <your-env> --file=https://raw.githubusercontent.com/KwanLab/Autometa/main/nextflow-env.yml
 ```
 
 #### Create new env
 
 ```bash
-conda create -n autometa-nf -c bioconda -c conda-forge nextflow>=20.10 nf-core==2.1
+conda env create --file=https://raw.githubusercontent.com/KwanLab/Autometa/main/nextflow-env.yml
 ```
 
 For developers

--- a/docs/source/nextflow-workflow.rst
+++ b/docs/source/nextflow-workflow.rst
@@ -191,6 +191,30 @@ start the pipeline launch process.
 
     nf-core launch KwanLab/Autometa -r main
 
+.. attention::
+
+    If you receive an error about schema parameters you may be able to resolve this
+    by first removing the existing project and pulling the desired ``KwanLab/Autometa``
+    project using ``nextflow``.
+
+    e.g.
+
+    If a local project exists (you can check with ``nextflow list``), first ``drop`` this project:
+
+    ``nextflow drop KwanLab/Autometa``
+
+    Now pull the desired revision:
+
+    .. code:: bash
+
+        nextflow pull KwanLab/Autometa -r 2.0.0
+        # or
+        nextflow pull KwanLab/Autometa -r main
+        # or
+        nextflow pull KwanLab/Autometa -r dev
+
+    Now select the revision that you downloaded using the nextflow pull command.
+
 You will then be asked to choose "Web based" or "Command line" for selecting/providing options.
 While it is possible to use the command line version, it is preferred and easier to use the web-based GUI.
 Use the arrow keys to select one or the other and then press return/enter.

--- a/nextflow-env.yml
+++ b/nextflow-env.yml
@@ -7,5 +7,5 @@ channels:
 
 dependencies:
   - nextflow>=20.10
-  - bioconda::nf-core==2.1
+  - bioconda::nf-core==2.2
   - python>=3.8


### PR DESCRIPTION
## Docker CI/CD

:whale::green_heart: Dynamically tags `jasonkwan/autometa:tag` where `tag` is updated with a list of tags:

- :whale::green_heart: default branch is tagged with `latest`
- :whale::green_heart:  `dev` and `main` branches are tagged with their branch name
- :whale::green_heart:  releases are tagged with their release value, i.e. `2.0.0` is `jasonkwan/autometa:2.0.0`

## Docs

- :memo::crab::green_apple: Added an `attention` block under Using `nf-core` section as nf-core may fail
when trying to use a local copy of a revision for the `KwanLab/Autometa` project that is not in sync with the GitHub revision
