### PR TITLE
:bug::fire: Fix bedtools coverage calculation bug

### DIFF
--- a/autometa/common/external/bedtools.py
+++ b/autometa/common/external/bedtools.py
@@ -102,9 +102,7 @@ def parse(bed: str, out: str = None, force: bool = False) -> pd.DataFrame:
         raise FileNotFoundError(bed)
     names = ["contig", "depth", "bases", "length", "depth_fraction"]
     df = pd.read_csv(bed, sep="\t", names=names, index_col="contig")
-    criterion1 = df.depth != 0
-    criterion2 = df.index != "genome"
-    df = df[criterion1 & criterion2]
+    df = df[df.index != "genome"]
     df = df.assign(depth_product=lambda x: x.depth * x.bases)
     dff = df.groupby("contig")["depth_product", "bases"].sum()
     dff = dff.assign(coverage=lambda x: x.depth_product / x.bases)


### PR DESCRIPTION
:bug::fire: Fix coverage calculation bug where lengths of contigs did not match when portion of the contig had 0 depth 

Fixes #239 
Thanks to @chtsai0105 for finding and pointing this out!
