### PR TITLE
allow utf-8-sig sample sheet files

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -72,7 +72,7 @@ def check_samplesheet(file_in, file_out):
         "cov_from_assembly",
     ]
     num_required_cols = len(req_header_cols)
-    with open(file_in, "r") as fh:
+    with open(file_in, "r", encoding='utf-8-sig') as fh:
         ## Check header
         header = fh.readline().strip()
         header_cols = [header_col.strip('"') for header_col in header.split(",")]


### PR DESCRIPTION
fixes #249 

`utf-8-sig` codec should properly handle both utf-8 and utf-8-sig
https://peps.python.org/pep-0393/

<!--
# KwanLab/Autometa pull request

Many thanks for contributing to KwanLab/Autometa!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release or hotfix on the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
