### PR TITLE
:art::fire::green_apple: Replace incorrect runtime defaults

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ manifest {
     doi = "https://doi.org/10.1093/nar/gkz148"
     mainScript = "main.nf"
     nextflowVersion = ">=21.04.0"
-    version = "2.0.0"
+    version = "2.0.2"
 }
 
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -222,7 +222,7 @@
             "properties": {
                 "max_cpus": {
                     "type": "integer",
-                    "default": 16,
+                    "default": 4,
                     "fa_icon": "fas fa-microchip",
                     "description": "Max cpus to use/request"
                 },
@@ -234,7 +234,7 @@
                 },
                 "max_time": {
                     "type": "string",
-                    "default": "2d",
+                    "default": "240 h",
                     "fa_icon": "fas fa-clock",
                     "description": "Max time a *single* process is allowed to run"
                 },


### PR DESCRIPTION
- :green_apple::art::fire: fixes #251
- :green_apple::art: Replace `max_cpus` of `16` to `4` (actual default)
- :green_apple::art: Replace `max_time` of `2d` to `240 h` (actual default)
- :green_apple::whale::art: Bump version in manifest to `2.0.2`