### PR TITLE
:green_apple::snake::art: add exit status code of 204 for raised BinningError

### DIFF
--- a/autometa/binning/recursive_dbscan.py
+++ b/autometa/binning/recursive_dbscan.py
@@ -888,19 +888,30 @@ def main():
     logger.info(f"Selected clustering method: {args.clustering_method}")
 
     if args.taxonomy:
-        main_out = taxon_guided_binning(
-            main=main_df,
-            markers=markers_df,
-            completeness=args.completeness,
-            purity=args.purity,
-            coverage_stddev=args.cov_stddev_limit,
-            gc_content_stddev=args.gc_stddev_limit,
-            method=args.clustering_method,
-            starting_rank=args.starting_rank,
-            reverse_ranks=args.reverse_ranks,
-            n_jobs=args.cpus,
-            verbose=args.verbose,
-        )
+        try:
+            main_out = taxon_guided_binning(
+                main=main_df,
+                markers=markers_df,
+                completeness=args.completeness,
+                purity=args.purity,
+                coverage_stddev=args.cov_stddev_limit,
+                gc_content_stddev=args.gc_stddev_limit,
+                method=args.clustering_method,
+                starting_rank=args.starting_rank,
+                reverse_ranks=args.reverse_ranks,
+                n_jobs=args.cpus,
+                verbose=args.verbose,
+            )
+        except BinningError as err:
+            # Failed to recover any clusters from dataset
+            logger.warn(err)
+            logger.warn(
+                "This may be due to too few input contigs, too few marker-containing contigs, or some other reason!"
+            )
+            logger.warn(
+                "Please inspect your input data before proceeding with this dataset!"
+            )
+            sys.exit(204)
     else:
         # Perform clustering w/o taxonomy
         main_out = get_clusters(


### PR DESCRIPTION
- :snake: Add exit status code of `sys.exit(204)` for `BinningError('no clusters recovered')` in `autometa-binning`
- :snake::memo: Add extra warnings when this error is reached (i.e. Mentions as to why no clusters may have been recovered from this dataset and for the user to inspect their inputs).
- :green_apple::bug: Previously if no clusters were recovered from a particular dataset, the entire workflow would terminate, even though this dataset should just be ignored for downstream processes.

- :green_apple: `binning.nf` module already ignores `204` exit status as this is 'no content', continuing with the other input datasets but ignoring this for downstream processes.
