### PR TITLE
:art::bug::snake: Convert 'unclassified' taxids of 0 to root taxid of 1

### DIFF
--- a/autometa/validation/benchmark.py
+++ b/autometa/validation/benchmark.py
@@ -228,6 +228,11 @@ def get_target_labels(
     pred_df = pd.read_csv(
         prediction, sep="\t", index_col="contig", usecols=["contig", "taxid"]
     ).convert_dtypes()
+    # Convert taxids of 0 to 1 (some taxon-profilers assign unclassified to 0)
+    logger.debug(pred_df[pred_df.taxid.eq(0)].index.unique().tolist())
+    logger.debug(f"Converting {pred_df.taxid.eq(0).sum():,} taxids from 0 to 1")
+    pred_df.taxid = pred_df.taxid.map(lambda tid: 1 if tid == 0 else tid)
+
     if not isinstance(reference, pd.DataFrame) and isinstance(reference, str):
         ref_df = (
             pd.read_csv(


### PR DESCRIPTION
:art::snake: Some taxon-profilers assign unclassified contigs to a taxid of 0 where others assign root taxid of 1.

The NCBI class method of converting the taxid datatype expects a positive integer, so we are converting the unclassified taxid of 0 to the root taxid of 1. All input predictions will be converted in this same way. The contigs with their converted taxids as well as the number of 'unclassified' taxids are now emitted in the logs during conversion.