### PR TITLE
:art::bug::snake: Fix `autometa-length-filter` bug when `--output-fasta` is specified without an output directory

### DIFF
--- a/autometa/common/metagenome.py
+++ b/autometa/common/metagenome.py
@@ -286,7 +286,7 @@ class Metagenome:
             raise FileExistsError(out)
         logger.info(f"Getting contigs greater than or equal to {cutoff:,} bp")
         records = [record for record in self.seqrecords if len(record.seq) >= cutoff]
-        outdir = os.path.dirname(out)
+        outdir = os.path.dirname(os.path.abspath(out))
         if not os.path.exists(outdir):
             os.makedirs(outdir)
             logger.debug(f"Created outdir: {outdir}")


### PR DESCRIPTION
When using the `autometa-length-filter` entrypoint, if `--output-fasta` is not specified with `./metagenome.filtered.fna` (or to a separate directory), e.g. `autometa-length-filter ... --output-fasta metagenome.filtered.fna` a `FileNotFoundError` will occur. Getting the absolute path of the output specified prior to checking the output directory of the output specified will prevent this error.


```bash
(autometa) evan@userserver:~/Autometa$ autometa-length-filter --assembly tests/data/78.125Mbp.fna.gz --output-fasta test.fna --output-gc-content test.gc_content.tsv 
[04/05/2022 02:04:35 PM INFO] autometa.common.metagenome: Getting contigs greater than or equal to 3,000 bp
Traceback (most recent call last):
  File "/home/evan/miniconda3/envs/autometa/bin/autometa-length-filter", line 33, in <module>
    sys.exit(load_entry_point('Autometa==2.0.0', 'console_scripts', 'autometa-length-filter')())
  File "/home/evan/miniconda3/envs/autometa/lib/python3.9/site-packages/Autometa-2.0.0-py3.9.egg/autometa/common/metagenome.py", line 380, in main
    filtered_mg = raw_mg.length_filter(
  File "/home/evan/miniconda3/envs/autometa/lib/python3.9/site-packages/Autometa-2.0.0-py3.9.egg/autometa/common/utilities.py", line 422, in wrapper
    obj = func(*args, **kwds)
  File "/home/evan/miniconda3/envs/autometa/lib/python3.9/site-packages/Autometa-2.0.0-py3.9.egg/autometa/common/metagenome.py", line 291, in length_filter
    os.makedirs(outdir)
  File "/home/evan/miniconda3/envs/autometa/lib/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''
```

### To check

```bash
git checkout file-io
# checkout branch
make install
# Now run the command again and voilá
```


```bash
(autometa) evan@userserver:~/Autometa$ autometa-length-filter --assembly tests/data/78.125Mbp.fna.gz --output-fasta test.fna --output-gc-content test.gc_content.tsv 
[04/05/2022 02:05:04 PM INFO] autometa.common.metagenome: Getting contigs greater than or equal to 3,000 bp
[04/05/2022 02:05:05 PM INFO] autometa.common.utilities: length_filter took 1.29 seconds
[04/05/2022 02:05:06 PM INFO] autometa.common.utilities: gc_content took 1.26 seconds
```