### PR TITLE
Iss257

### DIFF
--- a/autometa/common/utilities.py
+++ b/autometa/common/utilities.py
@@ -16,6 +16,7 @@ import socket
 import sys
 import tarfile
 import time
+import subprocess
 from types import FunctionType
 from typing import Any
 
@@ -439,6 +440,29 @@ def internet_is_connected(
     except socket.error:
         return False
 
+def ncbi_is_connected(
+    filepath: str = "rsync://ftp.ncbi.nlm.nih.gov/genbank/GB_Release_Number"
+) -> bool:
+    """Check if ncbi databases are reachable. This can be used instead of a check for internet connection.
+
+    Parameters
+    ----------
+    filepath : string
+        filepath to NCBI's rsync server. Default is rsync://ftp.ncbi.nlm.nih.gov/genbank/GB_Release_Number,
+        which should be a very small file that is unlikely to move. This may need to be updated if NCBI changes
+        their file organization.
+
+    Outputs
+    -------
+    True or False
+        True if the rsync server can be contacted without an error
+        False if the rsync process returns any error
+    """
+    cmd = ["rsync", "--quiet", "--dry-run", filepath]
+    if subprocess.check_call(cmd) == 0:
+        return True
+    else:
+        return False
 
 if __name__ == "__main__":
     print(

--- a/autometa/config/databases.py
+++ b/autometa/config/databases.py
@@ -10,7 +10,6 @@ of Autometa Databases.
 import logging
 import os
 import requests
-import socket
 import subprocess
 import tempfile
 
@@ -25,7 +24,7 @@ from autometa.common.utilities import untar
 from autometa.common.utilities import calc_checksum
 from autometa.common.utilities import read_checksum
 from autometa.common.utilities import write_checksum
-from autometa.common.utilities import internet_is_connected
+from autometa.common.utilities import ncbi_is_connected
 from autometa.common.exceptions import ChecksumMismatchError
 from autometa.common.external import diamond
 from autometa.common.external import hmmscan
@@ -199,8 +198,8 @@ class Databases:
             raise ValueError(
                 f"'section' must be 'ncbi' or 'markers'. Provided: {section}"
             )
-        if not internet_is_connected():
-            raise ConnectionError("Cannot connect to the internet")
+        if not ncbi_is_connected():
+            raise ConnectionError("Cannot connect to the NCBI rsync server")
         if section == "ncbi":
             host = self.config.get(section, "host")
             ftp_fullpath = self.config.get("checksums", option)


### PR DESCRIPTION
<!--
# KwanLab/Autometa pull request

Many thanks for contributing to KwanLab/Autometa!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release or hotfix on the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

This addresses #257 by adding a function `ncbi_is_connected()` to the utilities. This function can be used in instances where Autometa is downloading from NCBI. I have changed references to the previous network checking function, `internet_is_connected()`, within the `config/databases.py` script. 

I have left `internet_is_connected()` in the `common/utilities.py` script, since it is used in dataset downloading from google drive. It makes more sense to ping google in that case.

I have tested the function by turning my internet connection on and off, but would welcome any input on creating more robust tests for this!

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Have you followed the pipeline conventions in the [contribution docs](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
