### PR TITLE
:snake::bug: Fix parsing taxids to delnodes set

### DIFF
--- a/autometa/taxonomy/ncbi.py
+++ b/autometa/taxonomy/ncbi.py
@@ -401,7 +401,7 @@ class NCBI:
         for line in tqdm(
             fh, disable=self.disable, desc="parsing delnodes", leave=False
         ):
-            del_taxid = line.strip("\t|\n")
+            del_taxid = int(line.strip("\t|\n"))
             delnodes.add(del_taxid)
         fh.close()
         if self.verbose:


### PR DESCRIPTION
:snake::bug: delnodes.dmp taxids were parsed and added to the `self.delnodes` set. However these taxids were not converted to integers prior to being stored within the set, causing a check of a current taxid (an integer) to return `False` due to the taxid's string representation being stored.