### PR TITLE
:art::green_apple: Add `autometa --version` to autometa nextflow files

### DIFF
--- a/modules/local/analyze_kmers.nf
+++ b/modules/local/analyze_kmers.nf
@@ -41,6 +41,6 @@ process ANALYZE_KMERS {
             --cpus "${task.cpus}" \\
             --seed 42
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/binning.nf
+++ b/modules/local/binning.nf
@@ -28,6 +28,7 @@ process BINNING {
         path  '*.version.txt'                                         , emit: version
 
     script:
+        def software = getSoftwareName(task.process)
         taxonomy_call = params.taxonomy_aware ? "--taxonomy $taxonomy" : "" // https://github.com/nextflow-io/nextflow/issues/1694#issuecomment-683272275
         """
         autometa-binning \\
@@ -48,6 +49,6 @@ process BINNING {
             --rank-filter superkingdom \\
             --rank-name-filter ${params.kingdom}
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/binning_summary.nf
+++ b/modules/local/binning_summary.nf
@@ -41,6 +41,6 @@ process BINNING_SUMMARY {
             --output-taxonomy "metabin_taxonomy.tsv" \\
             --output-metabins "metabins"
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/count_kmers.nf
+++ b/modules/local/count_kmers.nf
@@ -33,6 +33,6 @@ process COUNT_KMERS {
             --cpus "${task.cpus}" \\
             --seed 42
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/embed_kmers.nf
+++ b/modules/local/embed_kmers.nf
@@ -38,6 +38,6 @@ process EMBED_KMERS {
             --cpus "${task.cpus}" \\
             --seed 42
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/get_software_versions.nf
+++ b/modules/local/get_software_versions.nf
@@ -6,7 +6,7 @@ options        = initOptions(params.options)
 
 /*
 This file is left in from the template, that's mainly used for QUAST (http://cab.spbu.ru/software/quast/).
- There's a discussion that can be had later about incorporating that module fully or removing the remaining template that feeds into it
+There's a discussion that can be had later about incorporating that module fully or removing the remaining template that feeds into it
 */
 
 process GET_SOFTWARE_VERSIONS {
@@ -40,6 +40,6 @@ process GET_SOFTWARE_VERSIONS {
         echo $workflow.nextflow.version > nextflow.version.txt
         scrape_software_versions.py &> software_versions_mqc.yaml
 
-        echo "make linter happy" > autometa.version.txt
+        echo "make linter happy" > ${software}.version.txt
         """
 }

--- a/modules/local/hmmer_hmmsearch_filter.nf
+++ b/modules/local/hmmer_hmmsearch_filter.nf
@@ -47,6 +47,6 @@ process HMMER_HMMSEARCH_FILTER {
             --seqdb "$fasta" \\
             --out "markers.tsv"
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/length_table.nf
+++ b/modules/local/length_table.nf
@@ -36,6 +36,6 @@ process LENGTH_TABLE {
         lengths.index.name = "contig"
         lengths.to_csv(lengths.tsv, sep="\t", index=True, header=True)
 
-        echo "TODO" > ${software}.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/majority_vote.nf
+++ b/modules/local/majority_vote.nf
@@ -30,7 +30,6 @@ process MAJORITY_VOTE {
         """
         autometa-taxonomy-majority-vote --lca ${lca} --output votes.tsv --dbdir "${ncbi_tax_dir}"
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }
-

--- a/modules/local/markers.nf
+++ b/modules/local/markers.nf
@@ -50,6 +50,6 @@ process MARKERS {
             --hmmdb "/scratch/dbs/markers/${params.kingdom}.single_copy.hmm" \\
             --cutoffs "/scratch/dbs/markers/${params.kingdom}.single_copy.cutoffs"
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/normalize_kmers.nf
+++ b/modules/local/normalize_kmers.nf
@@ -32,6 +32,6 @@ process NORMALIZE_KMERS {
             --norm-method "${params.norm_method}" \\
             --seed 42
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/parse_bed.nf
+++ b/modules/local/parse_bed.nf
@@ -37,6 +37,6 @@ process PARSE_BED {
             --bed $bed \\
             --output coverage.tsv
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/prepare_lca.nf
+++ b/modules/local/prepare_lca.nf
@@ -34,6 +34,6 @@ process PREPARE_LCA {
             --dbdir ${blastdb_dir} \\
             --cache cache \\
             --only-prepare-cache
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/reduce_lca.nf
+++ b/modules/local/reduce_lca.nf
@@ -39,6 +39,6 @@ process REDUCE_LCA {
             --lca-error-taxids lca_error_taxids.tsv \\
             --sseqid2taxid-output sseqid2taxid.tsv \\
             --lca-output lca.tsv
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/spades_kmer_coverage.nf
+++ b/modules/local/spades_kmer_coverage.nf
@@ -36,6 +36,6 @@ process SPADES_KMER_COVERAGE {
             --from-spades \\
             --out "coverage.tsv"
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/split_kingdoms.nf
+++ b/modules/local/split_kingdoms.nf
@@ -38,6 +38,6 @@ process SPLIT_KINGDOMS {
             --assembly "${assembly}" \\
             --ncbi "${ncbi_tax_dir}"
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/modules/local/unclustered_recruitment.nf
+++ b/modules/local/unclustered_recruitment.nf
@@ -45,7 +45,7 @@ process RECRUIT {
             --output-main ${params.kingdom}.recruitment.main.tsv.gz \\
             --output-features ${params.kingdom}.recruitment.features.tsv.gz
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
         else
         """
@@ -62,6 +62,6 @@ process RECRUIT {
             --output-main ${params.kingdom}.recruitment.main.tsv.gz \\
             --output-features ${params.kingdom}.recruitment.features.tsv.gz
 
-        echo "TODO" > autometa.version.txt
+        autometa --version | sed -e "s/autometa: //g" > ${software}.version.txt
         """
 }

--- a/workflows/autometa.sh
+++ b/workflows/autometa.sh
@@ -48,6 +48,9 @@ fi
 
 ######### BEGIN #########
 
+# Step 00: Report autometa version
+autometa --version
+
 # Step 1: filter assembly by length and retrieve contig lengths as well as GC content
 
 # input:
@@ -223,7 +226,7 @@ for kingdom in ${kingdoms[@]};do
     # script:
     autometa-binning \
         --kmers $kmers \
-        --coverages $coverage \
+        --coverages $coverages \
         --gc-content $gc_content \
         --markers $markers \
         --output-binning $output_binning \


### PR DESCRIPTION
* :shell::bug: Replace incorrect variable name of `$coverage` with `$coverages` in bash autometa.sh workflow

## Add tracking of autometa version in nextflow processes
The `echo "TODO" > autometa.version.txt` within the autometa nextflow processes have been replaced with the recently added `autometa --version` command. This is now being redirected to the retrieved process name as defined by 

```nextflow
# ...
def software = getSoftwareName(task.process)
# ...
autometa --version | sed "s/autometa: //g" > ${software}.version.txt
```

## Fix variable name bug in autometa bash workflow

- The coverages output is assigned the `$coverages` variable, but is called `$coverage` within the `autometa-binning` entrypoint. This has been updated to the appropriate variable (`$coverages`) as defined earlier in the script.
- The autometa version is now emitted at the beginning of the `autometa.sh` workflow with `autometa --version`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Have you followed the pipeline conventions in the [contribution docs](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
