### PR TITLE
:memo: Added contribution documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -66,6 +66,30 @@ First off, thanks for taking the time to contribute! :clap::+1::tada:
 
 7. Submit a pull request! To submit a pull request - see [instructions below](#pull-requests).
 
+### Testing code locally
+
+If you are testing the bash workflow and have updated an Autometa entrypoint, you will need to reinstall Autometa as follows:
+
+```
+cd Autometa
+make clean
+make install
+```
+
+The [Nextflow](https://www.nextflow.io/) workflow pulls [Docker](https://www.docker.com/) images, so in order to ensure that you are running your local updated code, 
+you must make a Docker image locally, and then tell Nextflow to use it. In the example below, `newfeature` is a name given to represent the branch you are working on.
+
+```
+cd Autometa
+docker build . --tag jasonkwan/autometa:newfeature
+```
+
+Then, when you test the Autometa Nextflow workflow, you can run it as follows from the Autometa directory.
+
+```
+nextflow run . --autometa_image_tag 'newfeature'
+```
+
 ## How can I contribute?
 
 ### Reporting Bugs

--- a/docs/source/how-to-contribute.rst
+++ b/docs/source/how-to-contribute.rst
@@ -1,6 +1,6 @@
-=======================
-Contributing Guidelines
-=======================
+=================
+How to contribute
+=================
 
 Autometa is an open-source project developed on GitHub. If you would like to help develop
 Autometa or have ideas for new features please see our `contributing guidelines <https://github.com/KwanLab/Autometa/blob/dev/.github/CONTRIBUTING.md>`__

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ Guide
    installation
    autometa-python-api
    scripts/usage
-   contribution-guidelines
+   how-to-contribute
    Autometa_modules/modules
    legacy-autometa
    license


### PR DESCRIPTION
This PR adds some details to `.github/CONTRIBUTING.md`. Specifically, it outlines how to test code locally through both the bash and nextflow workflows to ensure that local updated code is used. I also made a small change to the documentation - the section previously titled 'Contribution guidelines' is now titles 'How to contribute'. The reason for this is that `.github/CONTRIBUTING.md` contains the contributing guidelines, and the section of the docs is not the same and so having the same title is confusing. Especially as in the first part of that page it suggests looking at the contributing guidelines. A reader is likely to think "aren't I already doing that?".

<!--
# KwanLab/Autometa pull request

Many thanks for contributing to KwanLab/Autometa!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release or hotfix on the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [X] Have you followed the pipeline conventions in the [contribution docs](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
