### PR TITLE
:art::snake: Update deprecated pandas method invocation

### DIFF
--- a/autometa/common/external/bedtools.py
+++ b/autometa/common/external/bedtools.py
@@ -104,7 +104,7 @@ def parse(bed: str, out: str = None, force: bool = False) -> pd.DataFrame:
     df = pd.read_csv(bed, sep="\t", names=names, index_col="contig")
     df = df[df.index != "genome"]
     df = df.assign(depth_product=lambda x: x.depth * x.bases)
-    dff = df.groupby("contig")["depth_product", "bases"].sum()
+    dff = df.groupby("contig")[["depth_product", "bases"]].sum()
     dff = dff.assign(coverage=lambda x: x.depth_product / x.bases)
     if out and (not os.path.exists(out) or (os.path.exists(out) and force)):
         dff.to_csv(out, sep="\t", index=True, header=True)


### PR DESCRIPTION
Update bedtools column summation to prevent emit of `FutureWarning`:

```bash
/home/evan/miniconda3/envs/autometa/lib/python3.9/site-packages/autometa/common/external/bedtools.py:107: FutureWarning: Indexing with multiple keys (implicitly converted to a tuple of keys) will be deprecated, use a list instead.
  dff = df.groupby(contig)[depth_product, bases].sum()
```

Now explicitly passes list, e.g.

```python
dff = df.groupby(contig)[["depth_product", "bases"]].sum()
```


<!--
# KwanLab/Autometa pull request

Many thanks for contributing to KwanLab/Autometa!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release or hotfix on the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Have you followed the pipeline conventions in the [contribution docs](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
