### PR TITLE
:shell: Add feature: New batch file scripts for documentation

### DIFF
--- a/autometa/common/external/bedtools.py
+++ b/autometa/common/external/bedtools.py
@@ -104,7 +104,7 @@ def parse(bed: str, out: str = None, force: bool = False) -> pd.DataFrame:
     df = pd.read_csv(bed, sep="\t", names=names, index_col="contig")
     df = df[df.index != "genome"]
     df = df.assign(depth_product=lambda x: x.depth * x.bases)
-    dff = df.groupby("contig")["depth_product", "bases"].sum()
+    dff = df.groupby("contig")[["depth_product", "bases"]].sum()
     dff = dff.assign(coverage=lambda x: x.depth_product / x.bases)
     if out and (not os.path.exists(out) or (os.path.exists(out) and force)):
         dff.to_csv(out, sep="\t", index=True, header=True)

--- a/autometa/validation/cami.py
+++ b/autometa/validation/cami.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+COPYRIGHT
+Copyright 2022 Ian J. Miller, Evan R. Rees, Kyle Wolf, Siddharth Uppal,
+Shaurya Chanana, Izaak Miller, Jason C. Kwan
+
+This file is part of Autometa.
+
+Autometa is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Autometa is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Autometa. If not, see <http://www.gnu.org/licenses/>.
+COPYRIGHT
+
+Autometa module to format Autometa results to bioboxes data format (compatible with CAMI tools)
+
+Reformats Autometa binning results such that they may be submitted to CAMI for benchmarking assessment
+"""
+
+
+import logging
+from typing import Literal, Union
+import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+
+
+def format_taxon_binning(
+    df: pd.DataFrame, sample_id: str, version: str = "0.9.0"
+) -> str:
+    """Format autometa taxon binning results to be compatible with specified BioBox `version`.
+
+    Parameters
+    ----------
+
+    taxon_binning : Union[str,pd.DataFrame]
+        Path to (to-be-formatted) taxon_binning results
+        or `pd.DataFrame(index_col=range(0, n_rows), columns=[contig, taxid, ...])`
+
+    sample_id : str
+        Sample identifier, not the generating user or program name.
+        It MUST match the regular expression `[A-Za-z0-9\._]+.`
+
+    version : str, optional
+        Biobox version to format results, by default `"0.9"`
+
+    Returns
+    -------
+    str
+        formatted results ready to be written to a file path
+
+    Raises
+    -------
+    NotImplementedError
+        Specified `version` is not implemented
+    TypeError
+        `taxon_binning` must be a path to a taxon results file or pandas
+    ValueError
+        `taxon_binning` does not contain the required columns
+    """
+    biobox_version = f"@VERSION:{version}"
+    biobox_sampleid = f"@SAMPLEID:{sample_id}"
+    if "taxid" not in df.columns:
+        raise ValueError(
+            f"taxon_binning results require columns 'contig' and 'taxid'. contains: {df.columns}"
+        )
+    outcols = ["@@SEQUENCEID", "TAXID"]
+    if "cluster" in df.columns:
+        df = df.rename(columns={"cluster": "BINID"})
+        outcols.append("BINID")
+    df = df.rename(columns={"contig": "@@SEQUENCEID", "taxid": "TAXID"})[outcols]
+    df_str = df.to_csv(sep="\t", index=False, header=True)
+    return f"{biobox_version}\n{biobox_sampleid}\n{df_str}"
+
+
+def format_genome_binning(
+    df: pd.DataFrame, sample_id: str, version: str = "0.9.0"
+) -> str:
+    """Format autometa genome binning results to be compatible with specified BioBox `version`.
+
+    Parameters
+    ----------
+
+    genome_binning : Union[str,pd.DataFrame]
+        Path to (to-be-formatted) genome_binning results
+        or `pd.DataFrame(index_col=range(0, n_rows), columns=[contig, taxid, ...])`
+
+    sample_id : str
+        Sample identifier, not the generating user or program name.
+        It MUST match the regular expression `[A-Za-z0-9\._]+.`
+
+    version : str, optional
+        Biobox version to format results, by default `"0.9"`
+
+    Returns
+    -------
+    str
+        formatted results ready to be written to a file path
+
+    Raises
+    -------
+    NotImplementedError
+        Specified `version` is not implemented
+    TypeError
+        `genome_binning` must be a path to a taxon results file or pandas
+    ValueError
+        `genome_binning` does not contain the required columns
+    """
+    biobox_version = f"@VERSION:{version}"
+    biobox_sampleid = f"@SAMPLEID:{sample_id}"
+    if "cluster" not in df.columns:
+        raise ValueError(
+            f"genome_binning results require columns 'contig' and 'cluster'. contains: {df.columns}"
+        )
+    outcols = ["@@SEQUENCEID", "BINID"]
+    if "taxid" in df.columns:
+        df = df.rename(columns={"taxid": "TAXID"})
+        outcols.append("TAXID")
+    df = df.rename(columns={"contig": "@@SEQUENCEID", "cluster": "BINID"})[outcols]
+    df_str = df.to_csv(sep="\t", index=False, header=True)
+    return f"{biobox_version}\n{biobox_sampleid}\n{df_str}"
+
+
+def format_profiling(df: pd.DataFrame, sample_id: str, version: str) -> str:
+    raise NotImplementedError(
+        "Autometa currently does not perform profiling, are you sure this is the format you need?"
+    )
+
+
+def get_biobox_format(
+    predictions: Union[str, pd.DataFrame],
+    sample_id: str,
+    results_type: Literal["profiling", "genome_binning", "taxon_binning"],
+    version: str,
+) -> str:
+    versions = {"0.9.0"}
+    if version not in versions:
+        raise NotImplementedError(
+            f"{version} not implemented. Available versions: {', '.join(versions)}"
+        )
+
+    if isinstance(predictions, str):
+        df = pd.read_csv(predictions, sep="\t")
+    elif isinstance(predictions, pd.DataFrame):
+        df = predictions.copy()
+    else:
+        raise TypeError(
+            f"predictions must be a path to a file or a DataFrame object! Given: {type(predictions)}"
+        )
+
+    formatter_dispatcher = {
+        "profiling": format_profiling,
+        "genome_binning": format_genome_binning,
+        "taxon_binning": format_taxon_binning,
+    }
+    if results_type not in formatter_dispatcher:
+        raise ValueError(
+            f"{results_type} not in formatters! {', '.join(formatter_dispatcher.keys())}"
+        )
+
+    logger.info(
+        f"Formatting predictions to biobox {results_type} format (version:{version})"
+    )
+
+    formatter = formatter_dispatcher[results_type]
+    return formatter(df, sample_id=sample_id, version=version)
+
+
+def main():
+    import argparse
+    import logging as logger
+
+    logger.basicConfig(
+        format="[%(asctime)s %(levelname)s] %(name)s: %(message)s",
+        datefmt="%m/%d/%Y %I:%M:%S %p",
+        level=logger.DEBUG,
+    )
+    parser = argparse.ArgumentParser(
+        description="""
+        Format Autometa results to biobox format for compatibility with CAMI.
+
+        Note: All results tables must contain a 'contig' column and either 'taxid', or 'cluster' column.
+
+        bioboxes formatted columns will be written for both if both are within the provided results.
+        """,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--sample-predictions",
+        help="Path of autometa table containing relevant `results-type` columns",
+        required=True,
+    )
+    parser.add_argument(
+        "--sample-id",
+        help="CAMI Sample ID corresponding to `sample-predictions`",
+        required=True,
+    )
+    parser.add_argument(
+        "--results-type",
+        help="Type of results for formatter to convert",
+        choices=["profiling", "genome_binning", "taxon_binning"],
+        required=True,
+    )
+    parser.add_argument(
+        "--bioboxes-version",
+        help="bioboxes binning output format. For more info see: https://github.com/bioboxes/rfc/blob/4bb19a633a6a969c2332f1f298852114c5f89b1b/data-format/binning.mkd",
+        default="0.9.0",
+    )
+    parser.add_argument(
+        "--output", help="Path to write biobox formatted results", required=True
+    )
+    args = parser.parse_args()
+
+    biobox_results = get_biobox_format(
+        predictions=args.sample_predictions,
+        sample_id=args.sample_id,
+        results_type=args.results_type,
+        version=args.bioboxes_version,
+    )
+
+    with open(args.output, "w") as fh:
+        fh.write(biobox_results)
+
+    logger.info(f"Wrote bioboxes formatted results to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
             "autometa-binning-ldm-loginfo = autometa.binning.large_data_mode_loginfo:main",
             "autometa-unclustered-recruitment = autometa.binning.unclustered_recruitment:main",
             "autometa-download-dataset = autometa.validation.datasets:main",
+            "autometa-cami-format = autometa.validation.cami:main",
             "autometa-benchmark = autometa.validation.benchmark:main",
             "autometa = autometa.__main__:main",
         ]


### PR DESCRIPTION
<!--
# KwanLab/Autometa pull request

Many thanks for contributing to KwanLab/Autometa!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release or hotfix on the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->
:shell: Add feature: New batch file scripts for documentation

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Have you followed the pipeline conventions in the [contribution docs](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)

Attached: Three new batch files that remove much of the data prep (Saved as txt files because *.sh files aren't supported apparently). 
[autometa_bwa_kart.txt](https://github.com/KwanLab/Autometa/files/8920036/autometa_bwa_kart.txt)
[autometa_pairedend_builtin.txt](https://github.com/KwanLab/Autometa/files/8920038/autometa_pairedend_builtin.txt)
[autometa_spades.txt](https://github.com/KwanLab/Autometa/files/8920039/autometa_spades.txt)
One for when spades was used for the assembly, one where coverage is calculated using bwa/kart/samtools and one that uses the built in autometa coverages option with paired-end data. The spades one has been tested and ran successfully on the KwanLab server. A second test is ongoing on the agrp server in SA with a different, much larger dataset.  

Note: For autometa_bwa_kart.sh to work, bwa kart and samtools will need to be added to the autometa conda env set up. 

If you are happy with the scripts, I can create a QuickStart guide much as I did for the nextflow workflow. 