### PR TITLE
Allow the use of gtdb taxonomy in Autometa

### DIFF
--- a/autometa/binning/large_data_mode.py
+++ b/autometa/binning/large_data_mode.py
@@ -39,7 +39,7 @@ from autometa.common.markers import load as load_markers
 from autometa.common import kmers
 
 from autometa.common.exceptions import TableFormatError, BinningError
-from autometa.taxonomy.ncbi import NCBI
+from autometa.taxonomy.ncbi import TAXA_DB
 from autometa.binning.recursive_dbscan import get_clusters
 from autometa.binning.utilities import (
     write_results,
@@ -312,11 +312,11 @@ def cluster_by_taxon_partitioning(
     """
     if reverse_ranks:
         # species, genus, family, order, class, phylum, superkingdom
-        canonical_ranks = [rank for rank in NCBI.CANONICAL_RANKS if rank != "root"]
+        canonical_ranks = [rank for rank in TAXA_DB.CANONICAL_RANKS if rank != "root"]
     else:
         # superkingdom, phylum, class, order, family, genus, species
         canonical_ranks = [
-            rank for rank in reversed(NCBI.CANONICAL_RANKS) if rank != "root"
+            rank for rank in reversed(TAXA_DB.CANONICAL_RANKS) if rank != "root"
         ]
     # if stage is cached then we can first look to the cache before we begin subsetting main...
     clustered_contigs = set()

--- a/autometa/binning/recursive_dbscan.py
+++ b/autometa/binning/recursive_dbscan.py
@@ -24,7 +24,7 @@ from numba import config
 from autometa.common.markers import load as load_markers
 
 from autometa.common.exceptions import TableFormatError, BinningError
-from autometa.taxonomy.ncbi import NCBI
+from autometa.taxonomy.ncbi import TAXA_DB
 from autometa.binning.utilities import (
     write_results,
     read_annotations,
@@ -628,10 +628,10 @@ def taxon_guided_binning(
     logger.info(f"Using {method} clustering method")
     if reverse_ranks:
         # species, genus, family, order, class, phylum, superkingdom
-        ranks = [rank for rank in NCBI.CANONICAL_RANKS if rank != "root"]
+        ranks = [rank for rank in TAXA_DB.CANONICAL_RANKS if rank != "root"]
     else:
         # superkingdom, phylum, class, order, family, genus, species
-        ranks = [rank for rank in reversed(NCBI.CANONICAL_RANKS) if rank != "root"]
+        ranks = [rank for rank in reversed(TAXA_DB.CANONICAL_RANKS) if rank != "root"]
     starting_rank_index = ranks.index(starting_rank)
     ranks = ranks[starting_rank_index:]
     logger.debug(f"Using ranks: {', '.join(ranks)}")

--- a/autometa/binning/summary.py
+++ b/autometa/binning/summary.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from Bio import SeqIO
 
-from autometa.taxonomy.ncbi import NCBI
+from autometa.taxonomy.ncbi import TAXA_DB
 from autometa.taxonomy import majority_vote
 from autometa.common.markers import load as load_markers
 
@@ -226,7 +226,7 @@ def get_metabin_stats(
 
 
 def get_metabin_taxonomies(
-    bin_df: pd.DataFrame, ncbi: NCBI, cluster_col: str = "cluster"
+    bin_df: pd.DataFrame, ncbi: TAXA_DB, cluster_col: str = "cluster"
 ) -> pd.DataFrame:
     """Retrieve taxonomies of all clusters recovered from Autometa binning.
 
@@ -234,8 +234,8 @@ def get_metabin_taxonomies(
     ----------
     bin_df : pd.DataFrame
         Autometa binning table. index=contig, cols=['cluster','length','taxid', *canonical_ranks]
-    ncbi : autometa.taxonomy.ncbi.NCBI instance
-        Autometa NCBI class instance
+    ncbi : autometa.taxonomy.ncbi.TAXA_DB instance
+        Autometa TAXA_DB class instance
     cluster_col : str, optional
         Clustering column by which to group metabins
 
@@ -246,7 +246,7 @@ def get_metabin_taxonomies(
         Indexed by cluster
     """
     logger.info(f"Retrieving metabin taxonomies for {cluster_col}")
-    canonical_ranks = [rank for rank in NCBI.CANONICAL_RANKS if rank != "root"]
+    canonical_ranks = [rank for rank in TAXA_DB.CANONICAL_RANKS if rank != "root"]
     is_clustered = bin_df[cluster_col].notnull()
     bin_df = bin_df[is_clustered]
     outcols = [cluster_col, "length", "taxid", *canonical_ranks]
@@ -324,7 +324,7 @@ def main():
     )
     parser.add_argument(
         "--ncbi",
-        help="Path to user NCBI databases directory (Required for retrieving metabin taxonomies)",
+        help="Path to user TAXA_DB databases directory (Required for retrieving metabin taxonomies)",
         metavar="dirpath",
         required=False,
     )
@@ -382,7 +382,7 @@ def main():
                 "taxid found in dataframe. --ncbi argument is required to retrieve metabin taxonomies. Skipping..."
             )
         else:
-            ncbi = NCBI(dirpath=args.ncbi)
+            ncbi = TAXA_DB(dirpath=args.ncbi)
             taxa_df = get_metabin_taxonomies(
                 bin_df=bin_df, ncbi=ncbi, cluster_col=args.binning_column
             )

--- a/autometa/binning/utilities.py
+++ b/autometa/binning/utilities.py
@@ -33,7 +33,7 @@ import pandas as pd
 
 from typing import Iterable, Tuple
 
-from autometa.taxonomy.ncbi import NCBI
+from autometa.taxonomy.ncbi import TAXA_DB
 
 
 logger = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ def filter_taxonomy(df: pd.DataFrame, rank: str, name: str) -> pd.DataFrame:
         Provided `name` not found in `rank` column.
     """
     # First clean the assigned taxa by broadcasting lowercase and replacing any whitespace with underscores
-    for canonical_rank in NCBI.CANONICAL_RANKS:
+    for canonical_rank in TAXA_DB.CANONICAL_RANKS:
         if canonical_rank not in df.columns:
             continue
         df[canonical_rank] = df[canonical_rank].map(
@@ -395,7 +395,9 @@ def write_results(
         outcols.extend(annotation_cols)
         # Add in taxonomy columns if taxa are present
         # superkingdom, phylum, class, order, family, genus, species
-        taxa_cols = [rank for rank in reversed(NCBI.CANONICAL_RANKS) if rank != "root"]
+        taxa_cols = [
+            rank for rank in reversed(TAXA_DB.CANONICAL_RANKS) if rank != "root"
+        ]
         taxa_cols.append("taxid")
         # superkingdom, phylum, class, order, family, genus, species, taxid
         for taxa_col in taxa_cols:

--- a/autometa/common/exceptions.py
+++ b/autometa/common/exceptions.py
@@ -67,7 +67,7 @@ class ExternalToolError(AutometaError):
 
 class DatabaseOutOfSyncError(AutometaError):
     """
-    Raised when NCBI databases nodes.dmp, names.dmp and merged.dmp are out of sync with each other
+    Raised when TAXA_DB databases nodes.dmp, names.dmp and merged.dmp are out of sync with each other
     Parameters
     ----------
     AutometaError : class
@@ -87,7 +87,7 @@ class DatabaseOutOfSyncError(AutometaError):
             Message written alongside raising the exception
         """
         message = """
-        NCBI databases nodes.dmp, names.dmp, merged.dmp, prot.accession2taxid.gz and nr.gz may be out of sync.
+        TAXA_DB databases nodes.dmp, names.dmp, merged.dmp, prot.accession2taxid.gz and nr.gz may be out of sync.
         Up-to-date databases may be downloaded at:
         non-redundant protein database (nr) - ftp://ftp.ncbi.nlm.nih.gov/blast/db/FASTA/nr.gz
         prot.accession2taxid.gz - ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz

--- a/autometa/common/utilities.py
+++ b/autometa/common/utilities.py
@@ -449,8 +449,8 @@ def ncbi_is_connected(
     Parameters
     ----------
     filepath : string
-        filepath to NCBI's rsync server. Default is rsync://ftp.ncbi.nlm.nih.gov/genbank/GB_Release_Number,
-        which should be a very small file that is unlikely to move. This may need to be updated if NCBI changes
+        filepath to TAXA_DB's rsync server. Default is rsync://ftp.ncbi.nlm.nih.gov/genbank/GB_Release_Number,
+        which should be a very small file that is unlikely to move. This may need to be updated if TAXA_DB changes
         their file organization.
 
     Outputs

--- a/autometa/config/databases.py
+++ b/autometa/config/databases.py
@@ -63,7 +63,7 @@ class Databases:
 
     Attributes
     ----------
-    ncbi_dir : str </path/to/databases/ncbi> markers_dir : str
+    taxa_db_dir : str </path/to/databases/ncbi> markers_dir : str
         </path/to/databases/markers> SECTIONS : dict keys are `sections`
         respective to database config sections and values are options within
         the `sections`.
@@ -135,9 +135,9 @@ class Databases:
                 continue
             outdir = DEFAULT_CONFIG.get("databases", section)
             self.config.set("databases", section, outdir)
-        self.ncbi_dir = self.config.get("databases", "ncbi")
+        self.taxa_db_dir = self.config.get("databases", "ncbi")
         self.markers_dir = self.config.get("databases", "markers")
-        for outdir in {self.ncbi_dir, self.markers_dir}:
+        for outdir in {self.taxa_db_dir, self.markers_dir}:
             if not os.path.exists(outdir):
                 os.makedirs(outdir)
 
@@ -199,7 +199,7 @@ class Databases:
                 f"'section' must be 'ncbi' or 'markers'. Provided: {section}"
             )
         if not ncbi_is_connected():
-            raise ConnectionError("Cannot connect to the NCBI rsync server")
+            raise ConnectionError("Cannot connect to the TAXA_DB rsync server")
         if section == "ncbi":
             host = self.config.get(section, "host")
             ftp_fullpath = self.config.get("checksums", option)
@@ -319,7 +319,7 @@ class Databases:
             ("merged", "merged.dmp"),
         ]
         for option, fname in taxdump_files:
-            outfpath = os.path.join(self.ncbi_dir, fname)
+            outfpath = os.path.join(self.taxa_db_dir, fname)
             if self.dryrun:
                 logger.debug(f"UPDATE (ncbi,{option}): {outfpath}")
                 self.config.set("ncbi", option, outfpath)
@@ -329,14 +329,14 @@ class Databases:
                 os.remove(outfpath)
             # Only extract the taxdump files if this is not a "dryrun"
             if not os.path.exists(outfpath):
-                outfpath = untar(taxdump_fpath, self.ncbi_dir, fname)
+                outfpath = untar(taxdump_fpath, self.taxa_db_dir, fname)
             write_checksum(outfpath, f"{outfpath}.md5")
 
             logger.debug(f"UPDATE (ncbi,{option}): {outfpath}")
             self.config.set("ncbi", option, outfpath)
 
     def download_ncbi_files(self, options: Iterable) -> None:
-        """Download NCBI database files.
+        """Download TAXA_DB database files.
 
         Parameters
         ----------
@@ -351,9 +351,9 @@ class Databases:
         Raises
         -------
         subprocess.CalledProcessError
-            NCBI file download with rsync failed.
+            TAXA_DB file download with rsync failed.
         ConnectionError
-            NCBI file checksums do not match after file transfer.
+            TAXA_DB file checksums do not match after file transfer.
 
         """
         # s.t. set methods are available
@@ -374,7 +374,7 @@ class Databases:
                 outfpath = self.config.get("ncbi", option)
             else:
                 outfname = os.path.basename(ftp_fullpath)
-                outfpath = os.path.join(self.ncbi_dir, outfname)
+                outfpath = os.path.join(self.taxa_db_dir, outfname)
 
             logger.debug(f"UPDATE: (ncbi,{option}): {outfpath}")
             self.config.set("ncbi", option, outfpath)
@@ -674,7 +674,7 @@ class Databases:
         Raises
         -------
         ValueError Provided `section` does not match 'ncbi' or 'markers'.
-            ConnectionError A connection issue occurred when connecting to NCBI
+            ConnectionError A connection issue occurred when connecting to TAXA_DB
             or GitHub.
 
         """

--- a/autometa/taxonomy/majority_vote.py
+++ b/autometa/taxonomy/majority_vote.py
@@ -15,13 +15,13 @@ from typing import Dict, Union
 from tqdm import tqdm
 
 from autometa.taxonomy.lca import LCA
-from autometa.taxonomy.ncbi import NCBI, NCBI_DIR
+from autometa.taxonomy.ncbi import TAXA_DB, TAXA_DB_DIR
 
 logger = logging.getLogger(__name__)
 
 
 def is_consistent_with_other_orfs(
-    taxid: int, rank: str, rank_counts: Dict[str, Dict], ncbi: NCBI
+    taxid: int, rank: str, rank_counts: Dict[str, Dict], taxa_db: TAXA_DB
 ) -> bool:
     """Determines whether the majority of proteins in a contig, with rank equal
     to or above the given rank, are common ancestors of the taxid.
@@ -38,8 +38,8 @@ def is_consistent_with_other_orfs(
     rank_counts : dict
         LCA canonical rank counts retrieved from ORFs respective to a contig.
         e.g. {canonical_rank: {taxid: num_hits, ...}, ...}
-    ncbi : NCBI instance
-        Instance or subclass of NCBI from autometa.taxonomy.ncbi.
+    taxa_db : TAXA_DB instance
+        Instance or subclass of TAXA_DB from autometa.taxonomy.ncbi.
 
     Returns
     -------
@@ -48,8 +48,8 @@ def is_consistent_with_other_orfs(
         return True, otherwise return False.
 
     """
-    rank_index = NCBI.CANONICAL_RANKS.index(rank)
-    ranks_to_consider = NCBI.CANONICAL_RANKS[rank_index:]
+    rank_index = TAXA_DB.CANONICAL_RANKS.index(rank)
+    ranks_to_consider = TAXA_DB.CANONICAL_RANKS[rank_index:]
     # Now we total up the consistent and inconsistent ORFs
     consistent = 0
     inconsistent = 0
@@ -57,7 +57,7 @@ def is_consistent_with_other_orfs(
         if rank_name not in rank_counts:
             continue
         for rank_taxid, count in rank_counts[rank_name].items():
-            if ncbi.is_common_ancestor(rank_taxid, taxid):
+            if taxa_db.is_common_ancestor(rank_taxid, taxid):
                 consistent += count
             else:
                 inconsistent += count
@@ -70,7 +70,7 @@ def is_consistent_with_other_orfs(
         return False
 
 
-def lowest_majority(rank_counts: Dict[str, Dict], ncbi: NCBI) -> int:
+def lowest_majority(rank_counts: Dict[str, Dict], taxa_db: TAXA_DB) -> int:
     """Determine the lowest majority given `rank_counts` by first attempting to
     get a taxid that leads in counts with the highest specificity in terms of
     canonical rank.
@@ -79,8 +79,8 @@ def lowest_majority(rank_counts: Dict[str, Dict], ncbi: NCBI) -> int:
     ----------
     rank_counts : dict
         {canonical_rank:{taxid:num_hits, ...}, rank2: {...}, ...}
-    ncbi : NCBI instance
-        NCBI object from autometa.taxonomy.ncbi
+    taxa_db : TAXA_DB instance
+        TAXA_DB object from autometa.taxonomy.ncbi
 
     Returns
     -------
@@ -89,11 +89,11 @@ def lowest_majority(rank_counts: Dict[str, Dict], ncbi: NCBI) -> int:
 
     """
     taxid_totals = {}
-    for rank in NCBI.CANONICAL_RANKS:
+    for rank in TAXA_DB.CANONICAL_RANKS:
         if rank not in rank_counts:
             continue
-        rank_index = NCBI.CANONICAL_RANKS.index(rank)
-        ranks_to_consider = NCBI.CANONICAL_RANKS[rank_index:]
+        rank_index = TAXA_DB.CANONICAL_RANKS.index(rank)
+        ranks_to_consider = TAXA_DB.CANONICAL_RANKS[rank_index:]
         for taxid in rank_counts[rank]:
             # Make a dictionary to total the number of canonical ranks hit
             # while traversing the path so that we can add 'unclassified' to
@@ -106,22 +106,22 @@ def lowest_majority(rank_counts: Dict[str, Dict], ncbi: NCBI) -> int:
             current_taxid = taxid
             current_rank = rank
             while current_taxid != 1:
-                if current_rank not in set(NCBI.CANONICAL_RANKS):
-                    current_taxid = ncbi.parent(current_taxid)
-                    current_rank = ncbi.rank(current_taxid)
+                if current_rank not in set(TAXA_DB.CANONICAL_RANKS):
+                    current_taxid = taxa_db.parent(current_taxid)
+                    current_rank = taxa_db.rank(current_taxid)
                     continue
                 ranks_in_path[current_rank] += 1
                 if current_rank not in taxid_totals:
                     taxid_totals.update({current_rank: {current_taxid: 1}})
-                    current_taxid = ncbi.parent(current_taxid)
-                    current_rank = ncbi.rank(current_taxid)
+                    current_taxid = taxa_db.parent(current_taxid)
+                    current_rank = taxa_db.rank(current_taxid)
                     continue
                 if current_taxid in taxid_totals[current_rank]:
                     taxid_totals[current_rank][current_taxid] += 1
                 else:
                     taxid_totals[current_rank][current_taxid] = 1
-                current_taxid = ncbi.parent(current_taxid)
-                current_rank = ncbi.rank(current_taxid)
+                current_taxid = taxa_db.parent(current_taxid)
+                current_rank = taxa_db.rank(current_taxid)
             # Now go through ranks_in_path. Where total = 0, add 'unclassified'
             for rank_to_consider in ranks_to_consider:
                 if ranks_in_path[rank_to_consider] == 0:
@@ -135,7 +135,7 @@ def lowest_majority(rank_counts: Dict[str, Dict], ncbi: NCBI) -> int:
     # we need to add 'unclassified' to the relevant canonical taxonomic rank.
     # However, we must never allow 'unclassified' to win! (That just won't really tell us anything)
     # Now we need to determine which is the first level to have a majority
-    for rank in NCBI.CANONICAL_RANKS:
+    for rank in TAXA_DB.CANONICAL_RANKS:
         total_votes = 0
         taxid_leader = None
         taxid_leader_votes = 0
@@ -155,7 +155,7 @@ def lowest_majority(rank_counts: Dict[str, Dict], ncbi: NCBI) -> int:
 
 
 def rank_taxids(
-    ctg_lcas: dict, ncbi: Union[NCBI, LCA], verbose: bool = False
+    ctg_lcas: dict, taxa_db: Union[TAXA_DB, LCA], verbose: bool = False
 ) -> Dict[str, int]:
     """Votes for taxids based on modified majority vote system where if a
     majority does not exist, the lowest majority is voted.
@@ -164,8 +164,8 @@ def rank_taxids(
     ----------
     ctg_lcas : dict
         {ctg1:{canonical_rank:{taxid:num_hits,...},...}, ctg2:{...},...}
-    ncbi : ncbi.NCBI or lca.LCA object
-        instance of NCBI subclass or NCBI containing NCBI methods.
+    taxa_db : taxa_db.TAXA_DB or lca.LCA object
+        instance of TAXA_DB subclass or TAXA_DB containing TAXA_DB methods.
     verbose : bool
         Description of parameter `verbose` (the default is False).
 
@@ -184,7 +184,7 @@ def rank_taxids(
         ctg_lcas, disable=disable, total=n_contigs, desc=desc, leave=False
     ):
         acceptedTaxid = None
-        for rank in NCBI.CANONICAL_RANKS:
+        for rank in TAXA_DB.CANONICAL_RANKS:
             if acceptedTaxid is not None:
                 break
             # Order in descending order of votes
@@ -196,7 +196,7 @@ def rank_taxids(
                 )
                 for taxid in ordered_taxids:
                     if is_consistent_with_other_orfs(
-                        taxid, rank, ctg_lcas[contig], ncbi
+                        taxid, rank, ctg_lcas[contig], taxa_db
                     ):
                         acceptedTaxid = taxid
                         break
@@ -204,7 +204,7 @@ def rank_taxids(
         # draw, so we need to find the lowest taxonomic level where there is a
         # majority
         if acceptedTaxid is None:
-            acceptedTaxid = lowest_majority(ctg_lcas[contig], ncbi)
+            acceptedTaxid = lowest_majority(ctg_lcas[contig], taxa_db)
         top_taxids[contig] = acceptedTaxid
     return top_taxids
 
@@ -247,7 +247,7 @@ def write_votes(results: Dict[str, int], out: str) -> str:
 def majority_vote(
     lca_fpath: str,
     out: str,
-    ncbi_dir: str,
+    taxa_db_dir: str,
     verbose: bool = False,
     orfs: str = None,
 ) -> str:
@@ -259,8 +259,8 @@ def majority_vote(
         Path to lowest common ancestor assignments table.
     out : str
         Path to write assigned taxids.
-    ncbi_dir : str
-        Path to NCBI databases directory.
+    taxa_db_dir : str
+        Path to TAXA_DB databases directory.
     verbose : bool, optional
         Increase verbosity of logging stream
     orfs: str, optional
@@ -275,12 +275,12 @@ def majority_vote(
 
     """
     outdir = os.path.dirname(os.path.realpath(out))
-    lca = LCA(dbdir=ncbi_dir, verbose=verbose, cache=outdir)
+    lca = LCA(dbdir=taxa_db_dir, verbose=verbose, cache=outdir)
     # retrieve lca taxids for each contig
     classifications = lca.parse(lca_fpath=lca_fpath, orfs_fpath=orfs)
     # Vote for majority lca taxid from contig lca taxids
-    # We can pass in lca as the ncbi object here, because it is a subclass of NCBI.
-    voted_taxids = rank_taxids(ctg_lcas=classifications, ncbi=lca, verbose=verbose)
+    # We can pass in lca as the taxa_db object here, because it is a subclass of TAXA_DB.
+    voted_taxids = rank_taxids(ctg_lcas=classifications, taxa_db=lca, verbose=verbose)
     return write_votes(results=voted_taxids, out=out)
 
 
@@ -297,7 +297,7 @@ def main():
         "--output", help="Path to write voted taxid results table.", required=True
     )
     parser.add_argument(
-        "--dbdir", help="Path to NCBI databases directory.", default=NCBI_DIR
+        "--dbdir", help="Path to TAXA_DB databases directory.", default=TAXA_DB_DIR
     )
     parser.add_argument(
         "--orfs",
@@ -315,7 +315,7 @@ def main():
     majority_vote(
         lca_fpath=args.lca,
         out=args.output,
-        ncbi_dir=args.dbdir,
+        taxa_db_dir=args.dbdir,
         verbose=args.verbose,
         orfs=args.orfs,
     )


### PR DESCRIPTION
Allows the taxonomy scripts to use the GTDB database.

Code to test:

For  `autometa-taxonomy-lca `
```
autometa-taxonomy-lca --blast 78Mbp_gtdb_blastP.tsv --dbdir /media/bigdrive1/sidd/autometa_aim1_1/data/external/gtdbData_r207v2/test1/gtdb_to_diamond --lca-output 78Mbp_gtdb_lca_trial4.tsv --sseqid2taxid-output 78Mbp_gtdb_sseqid2taxid_trial4.tsv --lca-error-taxids 78Mbp_gtdb_lca-error-taxids_trial4.tsv --dbType gtdb
```
For  `autometa-taxonomy-majority-vote`

```
autometa-taxonomy-majority-vote --lca 78Mbp_gtdb_lca_trial4.tsv --output 78Mbp_gtdb_majority_vote_trial4.tsv --dbdir /media/bigdrive1/sidd/autometa_aim1_1/data/external/gtdbData_r207v2/test1/gtdb_to_diamond
```

For `autometa-taxonomy `

```
autometa-taxonomy --votes 78Mbp_gtdb_majority_vote_trial4.tsv --output trial4/ --assembly /media/bigdrive1/sidd/nextflow_trial/autometa_runs/78mbp_manual/interim/78mbp_metagenome.filtered.fna --prefix 78mbp_metagenome_trial4 --split-rank-and-write superkingdom --taxa-db /media/bigdrive1/sidd/autometa_aim1_1/data/external/gtdbData_r207v2/test1/gtdb_to_diamond
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Have you followed the pipeline conventions in the [contribution docs](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
