### PR TITLE
Propagate unclassified contigs

### DIFF
--- a/autometa/taxonomy/database.py
+++ b/autometa/taxonomy/database.py
@@ -59,6 +59,7 @@ class TaxonomyDatabase(ABC):
     Available attributes:
 
     CANONICAL_RANKS
+    UNCLASSIFIED
     """
 
     CANONICAL_RANKS = [
@@ -71,6 +72,7 @@ class TaxonomyDatabase(ABC):
         "superkingdom",
         "root",
     ]
+    UNCLASSIFIED="unclassified"
 
     @abstractmethod
     def parse_nodes(self) -> Dict[int, Dict[str, Union[str, int]]]:
@@ -100,7 +102,7 @@ class TaxonomyDatabase(ABC):
         Returns
         -------
         str
-            Name of provided `taxid` if `taxid` is found in names.dmp else 'unclassified'
+            Name of provided `taxid` if `taxid` is found in names.dmp else UNCLASSIFIED
 
         """
 
@@ -237,7 +239,7 @@ class TaxonomyDatabase(ABC):
         Returns
         -------
         str
-            Name of provided `taxid` if `taxid` is found in names.dmp else 'unclassified'
+            Name of provided `taxid` if `taxid` is found in names.dmp else autoattribute:: autometa.taxonomy.database.TaxonomyDatabsase.UNCLASSIFIED
 
         """
         try:
@@ -246,19 +248,19 @@ class TaxonomyDatabase(ABC):
             logger.warning(err)
             taxid = 0
         if not rank:
-            return self.names.get(taxid, "unclassified")
+            return self.names.get(taxid, TaxonomyDatabase.UNCLASSIFIED)
         if rank not in set(TaxonomyDatabase.CANONICAL_RANKS):
             logger.warning(f"{rank} not in canonical ranks!")
-            return "unclassified"
+            return TaxonomyDatabase.UNCLASSIFIED
         ancestor_taxid = taxid
         while ancestor_taxid != 1:
             ancestor_rank = self.rank(ancestor_taxid)
             if ancestor_rank == rank:
-                return self.names.get(ancestor_taxid, "unclassified")
+                return self.names.get(ancestor_taxid, TaxonomyDatabase.UNCLASSIFIED)
             ancestor_taxid = self.parent(ancestor_taxid)
         # At this point we have not encountered a name for the taxid rank
         # so we will place this as unclassified.
-        return "unclassified"
+        return TaxonomyDatabase.UNCLASSIFIED
 
     def rank(self, taxid: int) -> str:
         """
@@ -272,7 +274,7 @@ class TaxonomyDatabase(ABC):
         Returns
         -------
         str
-            rank name if taxid is found in nodes else "unclassified"
+            rank name if taxid is found in nodes else autoattribute:: autometa.taxonomy.database.TaxonomyDatabsase.UNCLASSIFIED
 
         """
         try:
@@ -280,7 +282,7 @@ class TaxonomyDatabase(ABC):
         except DatabaseOutOfSyncError as err:
             logger.warning(err)
             taxid = 0
-        return self.nodes.get(taxid, {"rank": "unclassified"}).get("rank")
+        return self.nodes.get(taxid, {"rank": TaxonomyDatabase.UNCLASSIFIED}).get("rank")
 
     def parent(self, taxid: int) -> int:
         """
@@ -368,7 +370,7 @@ class TaxonomyDatabase(ABC):
         taxids : iterable
             `taxids` whose lineage dataframe is being returned
         fillna : bool, optional
-            Whether to fill the empty cells  with 'unclassified' or not, default True
+            Whether to fill the empty cells  with autoattribute:: autometa.taxonomy.database.TaxonomyDatabsase.UNCLASSIFIED or not, default True
 
         Returns
         -------
@@ -408,5 +410,5 @@ class TaxonomyDatabase(ABC):
         df = pd.DataFrame(ranked_taxids).transpose()
         df.index.name = "taxid"
         if fillna:
-            df.fillna(value="unclassified", inplace=True)
+            df.fillna(value=TaxonomyDatabase.UNCLASSIFIED, inplace=True)
         return df

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -285,12 +285,12 @@ def write_ranks(
     classified_contigs = taxonomy.index.tolist()
     #create empty list for unclassified contigs, then iterate through all contigs and add the ones
     #missing from the list of classified contigs to the unclassified contig list
-    unclassified_contigs = []
+    unclassified_contigs = [contig for contig in contig_ids if contig not in classified_contigs]
     #export taxonomy column names to list
     taxonomy_columns = taxonomy.columns.values.tolist()
-    for contig in contig_ids:
-        if contig not in classified_contigs:
-                unclassified_contigs.append(contig)
+ #   for contig in contig_ids:
+ #       if contig not in classified_contigs:
+ #               unclassified_contigs.append(contig)
     #create dataframe with column names from taxonomy and contig IDs
     unclassified_df = pd.DataFrame(columns=taxonomy_columns)
     unclassified_df['contig'] = unclassified_contigs

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -273,13 +273,19 @@ def write_ranks(
         raise FileNotFoundError(assembly)
     if not os.path.exists(outdir):
         os.makedirs(outdir)
-    assembly_records = [record for record in SeqIO.parse(assembly, "fasta")]
+    assembly_records = [record for record in SeqIO.parse(assembly, "fasta")] #cannot compare seq records directly
+    #create list of all contig IDs
+    contig_ids = []
+    with open(assembly, 'r') as assembly_fh:
+        for line in assembly_fh.readlines():
+            if '>' in line:
+                contig_ids.append(line)
     #create list of all classified contigs
     classified_contigs = taxonomy.index.tolist()
     #create empty list for unclassified contigs, then iterate through all contigs and add the ones
     #missing from the list of classified contigs to the unclassified contig list
     unclassified_contigs = []
-    for contig in assembly_records:
+    for contig in contig_ids:
         if contig not in classified_contigs:
                 unclassified_contigs.append(contig)
     #export taxonomy column names to list

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -279,7 +279,7 @@ def write_ranks(
     with open(assembly, 'r') as assembly_fh:
         for line in assembly_fh.readlines():
             if '>' in line:
-                contig_ids.append(line)
+                contig_ids.append(line.strip().replace('>', ''))
     #create list of all classified contigs
     classified_contigs = taxonomy.index.tolist()
     #create empty list for unclassified contigs, then iterate through all contigs and add the ones

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -290,6 +290,7 @@ def write_ranks(
                 unclassified_contigs.append({"contig":contig})
     #export taxonomy column names to list
     taxonomy_columns = taxonomy.columns.values.tolist()
+    print(*taxonomy_columns)
     #create dataframe with column names from taxonomy and contig IDs
     unclassified_df = pd.DataFrame(unclassified_contigs, columns=taxonomy_columns)
     #set index to contig, append it to taxonomy, then populate rank for unclassified contigs with

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -291,7 +291,7 @@ def write_ranks(
     #export taxonomy column names to list
     taxonomy_columns = taxonomy.columns.values.tolist()
     #create dataframe with column names from taxonomy and contig IDs
-    unclassified_df = pd.DataFrame(unclassified_contigs, columns=taxonomy_columns, ignore_index=True)
+    unclassified_df = pd.DataFrame(unclassified_contigs, columns=taxonomy_columns)
     #set index to contig, append it to taxonomy, then populate rank for unclassified contigs with
     #the unclassified attribute
     unclassified_df.set_index('contig', inplace=True)

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -287,14 +287,11 @@ def write_ranks(
     unclassified_contigs = []
     for contig in contig_ids:
         if contig not in classified_contigs:
-                unclassified_contigs.append(contig)
+                unclassified_contigs.append({"contig":contig})
     #export taxonomy column names to list
     taxonomy_columns = taxonomy.columns.values.tolist()
-    #create empty dataframe with column names from taxonomy
-    unclassified_df = pd.DataFrame(columns=taxonomy_columns)
-    #add contig names from the unclassified contig list to the unclassified contig dataframe
-    for contig in unclassified_contigs:
-            unclassified_df = unclassified_df.append({'contig' : contig}, ignore_index=True)
+    #create dataframe with column names from taxonomy and contig IDs
+    unclassified_df = pd.DataFrame(unclassified_contigs, columns=taxonomy_columns, ignore_index=True)
     #set index to contig, append it to taxonomy, then populate rank for unclassified contigs with
     #the unclassified attribute
     unclassified_df.set_index('contig', inplace=True)

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -17,7 +17,6 @@ import pandas as pd
 from Bio import SeqIO
 from typing import Union, List, Literal
 
-import pdb
 
 from autometa.common.external import prodigal
 from autometa.taxonomy import majority_vote

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -17,6 +17,7 @@ import pandas as pd
 from Bio import SeqIO
 from typing import Union, List, Literal
 
+import pdb
 
 from autometa.common.external import prodigal
 from autometa.taxonomy import majority_vote
@@ -285,14 +286,14 @@ def write_ranks(
     #create empty list for unclassified contigs, then iterate through all contigs and add the ones
     #missing from the list of classified contigs to the unclassified contig list
     unclassified_contigs = []
-    for contig in contig_ids:
-        if contig not in classified_contigs:
-                unclassified_contigs.append({"contig":contig})
     #export taxonomy column names to list
     taxonomy_columns = taxonomy.columns.values.tolist()
-    print(*taxonomy_columns)
+    for contig in contig_ids:
+        if contig not in classified_contigs:
+                unclassified_contigs.append(contig)
     #create dataframe with column names from taxonomy and contig IDs
-    unclassified_df = pd.DataFrame(unclassified_contigs, columns=taxonomy_columns)
+    unclassified_df = pd.DataFrame(columns=taxonomy_columns)
+    unclassified_df['contig'] = unclassified_contigs
     #set index to contig, append it to taxonomy, then populate rank for unclassified contigs with
     #the unclassified attribute
     unclassified_df.set_index('contig', inplace=True)

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -275,7 +275,7 @@ def write_ranks(
         os.makedirs(outdir)
     assembly_records = [record for record in SeqIO.parse(assembly, "fasta")]
     #create list of all classified contigs
-    classified_contigs = taxonomy['contig'].values.tolist()
+    classified_contigs = taxonomy.index.tolist()
     #create empty list for unclassified contigs, then iterate through all contigs and add the ones
     #missing from the list of classified contigs to the unclassified contig list
     unclassified_contigs = []

--- a/autometa/taxonomy/vote.py
+++ b/autometa/taxonomy/vote.py
@@ -291,7 +291,7 @@ def write_ranks(
     #export taxonomy column names to list
     taxonomy_columns = taxonomy.columns.values.tolist()
     #create empty dataframe with column names from taxonomy
-    unclassified_df = pd.Dataframe(columns=taxonomy_columns)
+    unclassified_df = pd.DataFrame(columns=taxonomy_columns)
     #add contig names from the unclassified contig list to the unclassified contig dataframe
     for contig in unclassified_contigs:
             unclassified_df = unclassified_df.append({'contig' : contig}, ignore_index=True)

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,10 @@
+#Dockerfile for documentation
+#
+#
+#
+#
+
+FROM sphinxdoc/sphinx
+WORKDIR /docs
+ADD requirements.txt /docs
+RUN pip3 install -r requirements.txt


### PR DESCRIPTION
updated to propagate contigs without blast hits to unclassified.fna

The code I showed Friday worked. I was keeping the unfiltered contigs due to a mistake in my bash script and it worked correctly after testing. The only part I haven't tested in an autometa run is the list comprehension in line 288 of vote.py but it worked fine in my jupyter notebook when making sure I was getting the right contigs and no extras.

Worth noting that the docstring I added for taxonomydatabase.UNCLASSIFIED is not building, but this may be an upstream issue per #311 