### PR TITLE
:snake::art::fire::bug: Fix UnboundLocalError bug

### DIFF
--- a/autometa/binning/large_data_mode.py
+++ b/autometa/binning/large_data_mode.py
@@ -344,30 +344,28 @@ def cluster_by_taxon_partitioning(
             binning_checkpoints_fpath = os.path.join(
                 cache, "binning_checkpoints.tsv.gz"
             )
-    if binning_checkpoints_fpath:
-        if os.path.exists(binning_checkpoints_fpath) and os.path.getsize(binning_checkpoints_fpath):
-            checkpoint_info = get_checkpoint_info(binning_checkpoints_fpath)
-            binning_checkpoints = checkpoint_info["binning_checkpoints"]
-            starting_rank = checkpoint_info["starting_rank"]
-            starting_rank_name_txt = checkpoint_info["starting_rank_name_txt"]
-            # Update datastructures to begin at checkpoint stage.
-            ## Forward fill binning annotations to most recent checkpoint and drop any contigs without bin annotations
-            most_recent_binning_checkpoint = (
-                binning_checkpoints.fillna(axis=1, method="ffill").iloc[:, -1].dropna()
-            )
-            clustered_contigs = set(
-                most_recent_binning_checkpoint.index.unique().tolist()
-            )
-            most_recent_clustered_df = most_recent_binning_checkpoint.to_frame().rename(
-                columns={starting_rank_name_txt: "cluster"}
-            )
-            num_clusters = most_recent_clustered_df.cluster.nunique()
-            clusters.append(most_recent_clustered_df)
-        else:
-            logger.debug(
-                f"Binning checkpoints not found. Writing checkpoints to {binning_checkpoints_fpath}"
-            )
-            binning_checkpoints = pd.DataFrame()
+    if binning_checkpoints_fpath and os.path.exists(binning_checkpoints_fpath) and os.path.getsize(binning_checkpoints_fpath):
+        checkpoint_info = get_checkpoint_info(binning_checkpoints_fpath)
+        binning_checkpoints = checkpoint_info["binning_checkpoints"]
+        starting_rank = checkpoint_info["starting_rank"]
+        starting_rank_name_txt = checkpoint_info["starting_rank_name_txt"]
+        # Update datastructures to begin at checkpoint stage.
+        ## Forward fill binning annotations to most recent checkpoint and drop any contigs without bin annotations
+        most_recent_binning_checkpoint = (
+            binning_checkpoints.fillna(axis=1, method="ffill").iloc[:, -1].dropna()
+        )
+        clustered_contigs = set(
+            most_recent_binning_checkpoint.index.unique().tolist()
+        )
+        most_recent_clustered_df = most_recent_binning_checkpoint.to_frame().rename(
+            columns={starting_rank_name_txt: "cluster"}
+        )
+        num_clusters = most_recent_clustered_df.cluster.nunique()
+        clusters.append(most_recent_clustered_df)
+    else:
+        logger_message = f"Binning checkpoints not found. Writing checkpoints to {binning_checkpoints_fpath}" if binning_checkpoints_fpath else "Binning checkpoints not found. Initializing..."
+        logger.debug(logger_message)
+        binning_checkpoints = pd.DataFrame()
 
     # Subset ranks by provided (or checkpointed) starting rank
     starting_rank_index = canonical_ranks.index(starting_rank)

--- a/autometa/binning/large_data_mode.py
+++ b/autometa/binning/large_data_mode.py
@@ -344,7 +344,11 @@ def cluster_by_taxon_partitioning(
             binning_checkpoints_fpath = os.path.join(
                 cache, "binning_checkpoints.tsv.gz"
             )
-    if binning_checkpoints_fpath and os.path.exists(binning_checkpoints_fpath) and os.path.getsize(binning_checkpoints_fpath):
+    if (
+        binning_checkpoints_fpath
+        and os.path.exists(binning_checkpoints_fpath)
+        and os.path.getsize(binning_checkpoints_fpath)
+    ):
         checkpoint_info = get_checkpoint_info(binning_checkpoints_fpath)
         binning_checkpoints = checkpoint_info["binning_checkpoints"]
         starting_rank = checkpoint_info["starting_rank"]
@@ -354,16 +358,18 @@ def cluster_by_taxon_partitioning(
         most_recent_binning_checkpoint = (
             binning_checkpoints.fillna(axis=1, method="ffill").iloc[:, -1].dropna()
         )
-        clustered_contigs = set(
-            most_recent_binning_checkpoint.index.unique().tolist()
-        )
+        clustered_contigs = set(most_recent_binning_checkpoint.index.unique().tolist())
         most_recent_clustered_df = most_recent_binning_checkpoint.to_frame().rename(
             columns={starting_rank_name_txt: "cluster"}
         )
         num_clusters = most_recent_clustered_df.cluster.nunique()
         clusters.append(most_recent_clustered_df)
     else:
-        logger_message = f"Binning checkpoints not found. Writing checkpoints to {binning_checkpoints_fpath}" if binning_checkpoints_fpath else "Binning checkpoints not found. Initializing..."
+        logger_message = (
+            f"Binning checkpoints not found. Writing checkpoints to {binning_checkpoints_fpath}"
+            if binning_checkpoints_fpath
+            else "Binning checkpoints not found. Initializing..."
+        )
         logger.debug(logger_message)
         binning_checkpoints = pd.DataFrame()
 


### PR DESCRIPTION
Remove unnecessary nesting leading to `UnboundLocalError` bug.

Fixes #324

UnboundLocalError resulted from trying to update `binning_checkpoints` dataframe when it was actually not available (occurs when `--cache` is *not* provided). Now variable is initialized accordingly to remove this error.

<!--
# KwanLab/Autometa pull request

Many thanks for contributing to KwanLab/Autometa!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release or hotfix on the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Have you followed the pipeline conventions in the [contribution docs](https://github.com/KwanLab/autometa/tree/main/.github/CONTRIBUTING.md)
