### PR TITLE
:fire::whale::green_heart: Fix docker-builds by removing pinned dependencies

### DIFF
--- a/.github/workflows/docker_autometa.yml
+++ b/.github/workflows/docker_autometa.yml
@@ -30,7 +30,7 @@ on:
     branches:
       - main
       - dev
-  schedule: 
+  schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
 jobs:
@@ -52,6 +52,7 @@ jobs:
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
             type=raw,value={{branch}}
             type=semver,pattern={{version}}
+            type=schedule,pattern=nightly
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1

--- a/.github/workflows/docker_autometa.yml
+++ b/.github/workflows/docker_autometa.yml
@@ -30,6 +30,8 @@ on:
     branches:
       - main
       - dev
+  schedule: 
+    - cron: '0 0 * * *'  # every day at midnight
 
 jobs:
   docker_autometa:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3
+FROM condaforge/mambaforge:latest 
 LABEL maintainer="jason.kwan@wisc.edu"
 
 # Copyright 2022 Ian J. Miller, Evan R. Rees, Kyle Wolf, Siddharth Uppal,
@@ -25,11 +25,12 @@ RUN apt-get update --allow-releaseinfo-change \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY autometa-env.yml ./
-RUN conda env update -n base --file=autometa-env.yml \
-    && conda clean --all -y
+RUN mamba env update -n base --file=autometa-env.yml \
+    && mamba clean --all -y
 
 
-COPY . .
+COPY . /Autometa
+WORKDIR /Autometa
 RUN make install && make clean
 
 # NOTE: DB_DIR must be an absolute path (not a relative path)

--- a/autometa-env.yml
+++ b/autometa-env.yml
@@ -25,7 +25,7 @@ dependencies:
   - samtools>=1.11
   - scikit-bio
   - scipy
-  - scikit-learn 
+  - scikit-learn
   - seqkit
   - tqdm
   - trimap

--- a/autometa-env.yml
+++ b/autometa-env.yml
@@ -12,7 +12,7 @@ dependencies:
   - gdown
   - hdbscan
   - hmmer
-  - joblib==1.1.0 # See https://stackoverflow.com/a/73830525/12671809
+  - joblib
   - numba>=0.47
   - numpy>=1.13
   - pandas>=1.1
@@ -24,8 +24,8 @@ dependencies:
   - rsync
   - samtools>=1.11
   - scikit-bio
-  - scipy==1.8.1 #force scipy 1.8 until scikit-bio updates to 1.9, https://github.com/KwanLab/Autometa/issues/285
-  - scikit-learn==0.24 # prevent error from joblib in multiprocessing distance calculations
+  - scipy
+  - scikit-learn 
   - seqkit
   - tqdm
   - trimap


### PR DESCRIPTION
- Add `schedule: cron: '0 0 * * *'` (i.e. midnight) build for Autometa docker images to catch when builds are failing
- :whale: Explicitly name workdir (`WORKDIR /Autometa`)
- :fire: Remove pinned versions for scipy, scikit-learn and joblib
- :whale: Replace base image with `condaforge/mambaforge`
- 🐎 :whale: Swap `conda` commands with `mamba` commands