### PR TITLE
:arrow_up: bump readthedocs-sphinx-search; 0.1.1 to 0.3.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==6.0
 sphinx_rtd_theme==1.2
-readthedocs-sphinx-search==0.1.1
+readthedocs-sphinx-search==0.3.2
 docutils>=0.18,<0.20


### PR DESCRIPTION
Fixes https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj