### PR TITLE
Fix Issue#349

### DIFF
--- a/autometa/binning/recursive_dbscan.py
+++ b/autometa/binning/recursive_dbscan.py
@@ -187,6 +187,8 @@ def recursive_dbscan(
             gc_content_stddev_cutoff=gc_content_stddev_cutoff,
         )
         median_completeness = filtered_df.completeness.median()
+        if pd.isna(median_completeness):
+            median_completeness = 0
         if median_completeness >= best_median:
             best_median = median_completeness
             best_df = df

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==6.0
 sphinx_rtd_theme==1.2
-readthedocs-sphinx-search==0.1.1
+readthedocs-sphinx-search==0.3.2
 docutils>=0.18,<0.20


### PR DESCRIPTION
`median_completeness` is being set to NA when `filtered_df` is empty. Which is causing the `TypeError: boolean value of NA is ambiguous` error reported in [issue#349](https://github.com/KwanLab/Autometa/issues/349).
Setting median completeness to 0 when it's NA seems to resolve this without causing any more bugs.
