### PR TITLE
Fix Issue#349

### DIFF
--- a/autometa/binning/recursive_dbscan.py
+++ b/autometa/binning/recursive_dbscan.py
@@ -187,6 +187,8 @@ def recursive_dbscan(
             gc_content_stddev_cutoff=gc_content_stddev_cutoff,
         )
         median_completeness = filtered_df.completeness.median()
+        if pd.isna(median_completeness):
+            median_completeness = 0
         if median_completeness >= best_median:
             best_median = median_completeness
             best_df = df

--- a/autometa/common/metagenome.py
+++ b/autometa/common/metagenome.py
@@ -312,7 +312,7 @@ class Metagenome:
             [
                 {
                     "contig": record.id,
-                    "gc_content": SeqUtils.gc_fraction(seq) * 100,
+                    "gc_content": SeqUtils.gc_fraction(record.seq) * 100,
                     "length": len(record.seq),
                 }
                 for record in self.seqrecords


### PR DESCRIPTION
`median_completeness` is being set to NA when `filtered_df` is empty. Which is causing the `TypeError: boolean value of NA is ambiguous` error reported in [issue#349](https://github.com/KwanLab/Autometa/issues/349).
Setting median completeness to 0 when it's NA seems to resolve this without causing any more bugs.